### PR TITLE
[TRUS-3616] - Implement Country code lookup in Welsh

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -28,6 +28,10 @@ import play.api.mvc.{Call, Request}
 @Singleton
 class FrontendAppConfig @Inject() (configuration: Configuration) {
 
+  final val ENGLISH = "en"
+  final val WELSH = "cy"
+  final val UK_COUNTRY_CODE = "GB"
+
   private val contactHost = configuration.get[String]("contact-frontend.host")
   private val contactFormServiceIdentifier = "trusts"
 
@@ -57,7 +61,7 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
   lazy val createAgentServicesAccountUrl : String = configuration.get[String]("urls.createAgentServicesAccount")
 
   lazy val locationCanonicalList: String = configuration.get[String]("location.canonical.list.all")
-  lazy val locationCanonicalListNonUK: String = configuration.get[String]("location.canonical.list.nonUK")
+  lazy val locationCanonicalListCY: String = configuration.get[String]("location.canonical.list.allCY")
 
   lazy val countdownLength: String = configuration.get[String]("timeout.countdown")
   lazy val timeoutLength: String = configuration.get[String]("timeout.length")
@@ -78,8 +82,8 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
     configuration.get[Boolean]("microservice.services.features.welsh-translation")
 
   def languageMap: Map[String, Lang] = Map(
-    "english" -> Lang("en"),
-    "cymraeg" -> Lang("cy")
+    "english" -> Lang(ENGLISH),
+    "cymraeg" -> Lang(WELSH)
   )
 
   def routeToSwitchLanguage: String => Call =

--- a/app/utils/CheckAnswersFormatters.scala
+++ b/app/utils/CheckAnswersFormatters.scala
@@ -48,7 +48,7 @@ object CheckAnswersFormatters {
 
   def formatNino(nino: String): String = Nino(nino).formatted
 
-  def country(code: String, countryOptions: CountryOptions): String =
+  def country(code: String, countryOptions: CountryOptions)(implicit messages: Messages): String =
     countryOptions.options.find(_.value.equals(code)).map(_.label).getOrElse("")
 
   def currency(value: String): Html = escape(s"£$value")
@@ -84,7 +84,7 @@ object CheckAnswersFormatters {
     Html(lines.mkString("<br />"))
   }
 
-  def internationalAddress(address: InternationalAddress, countryOptions: CountryOptions): Html = {
+  def internationalAddress(address: InternationalAddress, countryOptions: CountryOptions)(implicit messages: Messages): Html = {
     val lines =
       Seq(
         Some(HtmlFormat.escape(address.line1)),
@@ -96,14 +96,14 @@ object CheckAnswersFormatters {
     Html(lines.mkString("<br />"))
   }
 
-  def addressFormatter(address: Address, countryOptions: CountryOptions): Html = {
+  def addressFormatter(address: Address, countryOptions: CountryOptions)(implicit messages: Messages): Html = {
     address match {
       case a:UKAddress => ukAddress(a)
       case a:InternationalAddress => internationalAddress(a, countryOptions)
     }
   }
 
-  def passportOrIDCard(passportOrIdCard: PassportOrIdCardDetails, countryOptions: CountryOptions): Html = {
+  def passportOrIDCard(passportOrIdCard: PassportOrIdCardDetails, countryOptions: CountryOptions)(implicit messages: Messages): Html = {
     val lines =
       Seq(
         Some(country(passportOrIdCard.country, countryOptions)),

--- a/app/utils/countryOptions/CountryOptions.scala
+++ b/app/utils/countryOptions/CountryOptions.scala
@@ -20,6 +20,7 @@ import com.typesafe.config.ConfigException
 import config.FrontendAppConfig
 import javax.inject.{Inject, Singleton}
 import play.api.Environment
+import play.api.i18n.Messages
 import play.api.libs.json.Json
 import utils.InputOption
 
@@ -27,7 +28,14 @@ import utils.InputOption
 @Singleton
 class CountryOptions @Inject()(environment: Environment, config: FrontendAppConfig) {
 
-  def options: Seq[InputOption] = CountryOptions.getCountries(environment, config.locationCanonicalList)
+  def options()(implicit messages: Messages): Seq[InputOption] = {
+    CountryOptions.getCountries(environment, getFileName)
+  }
+
+  def getFileName()(implicit messages: Messages) = {
+    val isWelsh = messages.lang.code == config.WELSH
+    if (isWelsh) config.locationCanonicalListCY else config.locationCanonicalList
+  }
 
 }
 

--- a/app/utils/countryOptions/CountryOptionsNonUK.scala
+++ b/app/utils/countryOptions/CountryOptionsNonUK.scala
@@ -20,6 +20,7 @@ import com.google.inject.Inject
 import config.FrontendAppConfig
 import javax.inject.Singleton
 import play.api.Environment
+import play.api.i18n.Messages
 import utils.InputOption
 
 @Singleton
@@ -27,5 +28,7 @@ class CountryOptionsNonUK @Inject()(
                                         environment: Environment,
                                         config: FrontendAppConfig
                                       ) extends CountryOptions(environment, config) {
-  override def options: Seq[InputOption] = CountryOptions.getCountries(environment, config.locationCanonicalListNonUK)
+  override def options()(implicit messages: Messages): Seq[InputOption] = {
+    CountryOptions.getCountries(environment, getFileName).filterNot(x => x.value == config.UK_COUNTRY_CODE)
+  }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -43,7 +43,7 @@ play.filters.enabled += filters.SessionIdFilter
 
 location.canonical.list{
   all = "location-autocomplete-canonical-list.json"
-  nonUK = "location-canonical-list-nonUK.json"
+  allCY = "location-autocomplete-canonical-list-cy.json"
 }
 
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
@@ -85,7 +85,7 @@ microservice {
       }
 
       features {
-        welsh-translation: false
+        welsh-translation: true
       }
     }
 }

--- a/conf/location-autocomplete-canonical-list-cy.json
+++ b/conf/location-autocomplete-canonical-list-cy.json
@@ -4,7 +4,7 @@
     "country:AD"
   ],
   [
-    "United Arab Emirates",
+    "Yr Emiraethau Arabaidd Unedig",
     "country:AE"
   ],
   [
@@ -12,7 +12,7 @@
     "country:AF"
   ],
   [
-    "Antigua and Barbuda",
+    "Antigua a Barbuda",
     "country:AG"
   ],
   [
@@ -28,7 +28,7 @@
     "country:AM"
   ],
   [
-    "Dutch Antilles",
+    "Antilles yr Iseldiroedd",
     "country:AN"
   ],
   [
@@ -40,27 +40,27 @@
     "country:AQ"
   ],
   [
-    "Argentina",
+    "Yr Ariannin",
     "country:AR"
   ],
   [
-    "American Samoa",
+    "Samoa America",
     "country:AS"
   ],
   [
-    "Austria",
+    "Awstria",
     "country:AT"
   ],
   [
-    "Australia",
+    "Awstralia",
     "country:AU"
   ],
   [
-    "Aruba",
+    "Arwba",
     "country:AW"
   ],
   [
-    "Aland Islands",
+    "Ynysoedd Åland",
     "country:AX"
   ],
   [
@@ -68,7 +68,7 @@
     "country:AZ"
   ],
   [
-    "Bosnia and Herzegovina",
+    "Bosnia a Herzegovina",
     "country:BA"
   ],
   [
@@ -80,7 +80,7 @@
     "country:BD"
   ],
   [
-    "Belgium",
+    "Gwlad Belg",
     "country:BE"
   ],
   [
@@ -88,7 +88,7 @@
     "country:BF"
   ],
   [
-    "Bulgaria",
+    "Bwlgaria",
     "country:BG"
   ],
   [
@@ -104,7 +104,7 @@
     "country:BJ"
   ],
   [
-    "Saint Barthelemy",
+    "Saint Barthélemy",
     "country:BL"
   ],
   [
@@ -120,11 +120,11 @@
     "country:BO"
   ],
   [
-    "Bonaire, Sint Eustatius and Saba",
+    "Bonaire, Sint Eustatius a Saba",
     "country:BQ"
   ],
   [
-    "Brazil",
+    "Brasil",
     "country:BR"
   ],
   [
@@ -136,7 +136,7 @@
     "country:BT"
   ],
   [
-    "Bouvet Islands",
+    "Ynys Bouvet",
     "country:BV"
   ],
   [
@@ -156,31 +156,31 @@
     "country:CA"
   ],
   [
-    "Cocos (Keeling) Islands",
+    "Ynysoedd Cocos (Keeling)",
     "country:CC"
   ],
   [
-    "Democratic Republic of the Congo",
+    "Gweriniaeth Ddemocrataidd y Congo",
     "country:CD"
   ],
   [
-    "Central African Republic",
+    "Gweriniaeth Canol Affrica",
     "country:CF"
   ],
   [
-    "Republic of the Congo",
+    "Gweriniaeth y Congo",
     "country:CG"
   ],
   [
-    "Switzerland",
+    "Y Swistir",
     "country:CH"
   ],
   [
-    "Cote d'Ivoire",
+    "Côte d’Ivoire",
     "country:CI"
   ],
   [
-    "Cook Islands",
+    "Ynysoedd Cook",
     "country:CK"
   ],
   [
@@ -192,7 +192,7 @@
     "country:CM"
   ],
   [
-    "China",
+    "Tsieina",
     "country:CN"
   ],
   [
@@ -204,7 +204,7 @@
     "country:CR"
   ],
   [
-    "Serbia and Montenegro",
+    "Serbia a Montenegro",
     "country:CS"
   ],
   [
@@ -212,7 +212,7 @@
     "country:CU"
   ],
   [
-    "Cape Verde",
+    "Cabo Verde",
     "country:CV"
   ],
   [
@@ -220,7 +220,7 @@
     "country:CW"
   ],
   [
-    "Christmas Island",
+    "Ynys y Nadolig",
     "country:CX"
   ],
   [
@@ -228,11 +228,11 @@
     "country:CY"
   ],
   [
-    "Czech Republic",
+    "Y Weriniaeth Tsiec",
     "country:CZ"
   ],
   [
-    "Germany",
+    "Yr Almaen",
     "country:DE"
   ],
   [
@@ -240,7 +240,7 @@
     "country:DJ"
   ],
   [
-    "Denmark",
+    "Denmarc",
     "country:DK"
   ],
   [
@@ -248,7 +248,7 @@
     "country:DM"
   ],
   [
-    "Dominican Republic",
+    "Gweriniaeth Dominica",
     "country:DO"
   ],
   [
@@ -264,11 +264,11 @@
     "country:EE"
   ],
   [
-    "Egypt",
+    "Yr Aifft",
     "country:EG"
   ],
   [
-    "Western Sahara",
+    "Gorllewin Sahara",
     "country:EH"
   ],
   [
@@ -276,7 +276,7 @@
     "country:ER"
   ],
   [
-    "Spain",
+    "Sbaen",
     "country:ES"
   ],
   [
@@ -284,15 +284,15 @@
     "country:ET"
   ],
   [
-    "Finland",
+    "Y Ffindir",
     "country:FI"
   ],
   [
-    "Fiji",
+    "Ffiji",
     "country:FJ"
   ],
   [
-    "Falkland Islands",
+    "Ynysoedd Falkland",
     "country:FK"
   ],
   [
@@ -300,16 +300,20 @@
     "country:FM"
   ],
   [
-    "Faroe Islands",
+    "Ynysoedd Ffaröe",
     "country:FO"
   ],
   [
-    "France",
+    "Ffrainc",
     "country:FR"
   ],
   [
     "Gabon",
     "country:GA"
+  ],
+  [
+    "Y Deyrnas Unedig",
+    "country:GB"
   ],
   [
     "Grenada",
@@ -320,7 +324,7 @@
     "country:GE"
   ],
   [
-    "French Guiana",
+    "Guiana Ffrainc",
     "country:GF"
   ],
   [
@@ -336,7 +340,7 @@
     "country:GI"
   ],
   [
-    "Greenland",
+    "Yr Ynys Las",
     "country:GL"
   ],
   [
@@ -344,7 +348,7 @@
     "country:GM"
   ],
   [
-    "Guinea",
+    "Gini",
     "country:GN"
   ],
   [
@@ -352,27 +356,27 @@
     "country:GP"
   ],
   [
-    "Equatorial Guinea",
+    "Gini Gyhydeddol",
     "country:GQ"
   ],
   [
-    "Greece",
+    "Gwlad Groeg",
     "country:GR"
   ],
   [
-    "South Georgia and the Southern Sandwich Islands",
+    "Ynysoedd De Georgia a De Sandwich",
     "country:GS"
   ],
   [
-    "Guatemala",
+    "Gwatemala",
     "country:GT"
   ],
   [
-    "Guam",
+    "Gwam",
     "country:GU"
   ],
   [
-    "Guinea-Bissau",
+    "Guiné-Bissau",
     "country:GW"
   ],
   [
@@ -384,7 +388,7 @@
     "country:HK"
   ],
   [
-    "Heard Island and McDonald Islands",
+    "Ynys Heard ac Ynysoedd McDonald",
     "country:HM"
   ],
   [
@@ -400,7 +404,7 @@
     "country:HT"
   ],
   [
-    "Hungary",
+    "Hwngari",
     "country:HU"
   ],
   [
@@ -408,7 +412,7 @@
     "country:ID"
   ],
   [
-    "Ireland",
+    "Iwerddon",
     "country:IE"
   ],
   [
@@ -416,7 +420,7 @@
     "country:IL"
   ],
   [
-    "Isle of Man",
+    "Ynys Manaw",
     "country:IM"
   ],
   [
@@ -424,11 +428,11 @@
     "country:IN"
   ],
   [
-    "British Indian Ocean Territory",
+    "Tiriogaeth Brydeinig Cefnfor India",
     "country:IO"
   ],
   [
-    "Iraq",
+    "Irac",
     "country:IQ"
   ],
   [
@@ -436,11 +440,11 @@
     "country:IR"
   ],
   [
-    "Iceland",
+    "Gwlad yr Iâ",
     "country:IS"
   ],
   [
-    "Italy",
+    "Yr Eidal",
     "country:IT"
   ],
   [
@@ -452,7 +456,7 @@
     "country:JM"
   ],
   [
-    "Jordan",
+    "Gwlad yr Iorddonen",
     "country:JO"
   ],
   [
@@ -480,15 +484,15 @@
     "country:KM"
   ],
   [
-    "Saint Kitts and Nevis",
+    "Sant Kitts a Nevis",
     "country:KN"
   ],
   [
-    "North Korea",
+    "Gogledd Korea",
     "country:KP"
   ],
   [
-    "South Korea",
+    "De Korea",
     "country:KR"
   ],
   [
@@ -496,7 +500,7 @@
     "country:KW"
   ],
   [
-    "Cayman Islands",
+    "Ynysoedd Caiman",
     "country:KY"
   ],
   [
@@ -508,7 +512,7 @@
     "country:LA"
   ],
   [
-    "Lebanon",
+    "Libanus",
     "country:LB"
   ],
   [
@@ -536,7 +540,7 @@
     "country:LT"
   ],
   [
-    "Luxembourg",
+    "Lwcsembwrg",
     "country:LU"
   ],
   [
@@ -548,7 +552,7 @@
     "country:LY"
   ],
   [
-    "Morocco",
+    "Moroco",
     "country:MA"
   ],
   [
@@ -564,7 +568,7 @@
     "country:ME"
   ],
   [
-    "Saint Martin (French part)",
+    "Saint Martin (Rhan Ffrengig)",
     "country:MF"
   ],
   [
@@ -572,7 +576,7 @@
     "country:MG"
   ],
   [
-    "Marshall Islands",
+    "Ynysoedd Marshall",
     "country:MH"
   ],
   [
@@ -596,7 +600,7 @@
     "country:MO"
   ],
   [
-    "Northern Mariana Islands",
+    "Ynysoedd Gogledd Mariana",
     "country:MP"
   ],
   [
@@ -628,7 +632,7 @@
     "country:MW"
   ],
   [
-    "Mexico",
+    "Mecsico",
     "country:MX"
   ],
   [
@@ -636,7 +640,7 @@
     "country:MY"
   ],
   [
-    "Mozambique",
+    "Moçambique",
     "country:MZ"
   ],
   [
@@ -644,7 +648,7 @@
     "country:NA"
   ],
   [
-    "New Caledonia",
+    "Caledonia Newydd",
     "country:NC"
   ],
   [
@@ -652,7 +656,7 @@
     "country:NE"
   ],
   [
-    "Norfolk Islands",
+    "Ynys Norfolk",
     "country:NF"
   ],
   [
@@ -664,11 +668,11 @@
     "country:NI"
   ],
   [
-    "Netherlands",
+    "Yr Iseldiroedd",
     "country:NL"
   ],
   [
-    "Norway",
+    "Norwy",
     "country:NO"
   ],
   [
@@ -684,7 +688,7 @@
     "country:NU"
   ],
   [
-    "New Zealand",
+    "Seland Newydd",
     "country:NZ"
   ],
   [
@@ -692,23 +696,23 @@
     "country:OM"
   ],
   [
-    "Panama",
+    "Panamá",
     "country:PA"
   ],
   [
-    "Peru",
+    "Periw",
     "country:PE"
   ],
   [
-    "French Polynesia",
+    "Polynesia Ffrengig",
     "country:PF"
   ],
   [
-    "Papua New Guinea",
+    "Papua Guinea Newydd",
     "country:PG"
   ],
   [
-    "Philippines",
+    "Pilipinas",
     "country:PH"
   ],
   [
@@ -716,15 +720,15 @@
     "country:PK"
   ],
   [
-    "Poland",
+    "Gwlad Pwyl",
     "country:PL"
   ],
   [
-    "Saint Pierre and Miquelon",
+    "Saint Pierre a Miquelon",
     "country:PM"
   ],
   [
-    "Pitcairn Islands",
+    "Ynysoedd Pitcairn",
     "country:PN"
   ],
   [
@@ -732,11 +736,11 @@
     "country:PR"
   ],
   [
-    "Palestine",
+    "Palesteina",
     "country:PS"
   ],
   [
-    "Portugal",
+    "Portiwgal",
     "country:PT"
   ],
   [
@@ -756,7 +760,7 @@
     "country:RE"
   ],
   [
-    "Romania",
+    "România",
     "country:RO"
   ],
   [
@@ -764,7 +768,7 @@
     "country:RS"
   ],
   [
-    "Russia",
+    "Rwsia",
     "country:RU"
   ],
   [
@@ -776,7 +780,7 @@
     "country:SA"
   ],
   [
-    "Solomon Islands",
+    "Ynysoedd Solomon",
     "country:SB"
   ],
   [
@@ -784,7 +788,7 @@
     "country:SC"
   ],
   [
-    "Sudan",
+    "Swdan",
     "country:SD"
   ],
   [
@@ -792,11 +796,11 @@
     "country:SE"
   ],
   [
-    "Singapore",
+    "Singapôr",
     "country:SG"
   ],
   [
-    "Saint Helena, Ascension and Tristan da Cunha",
+    "Saint Helena, Ynys y Dyrchafael a Tristan da Cunha",
     "country:SH"
   ],
   [
@@ -804,7 +808,7 @@
     "country:SI"
   ],
   [
-    "Svalbard and Jan Mayen",
+    "Svalbard a Jan Mayen",
     "country:SJ"
   ],
   [
@@ -832,11 +836,11 @@
     "country:SR"
   ],
   [
-    "South Sudan",
+    "De Swdan",
     "country:SS"
   ],
   [
-    "Sao Tome and Principe",
+    "São Tomé a Príncipe",
     "country:ST"
   ],
   [
@@ -844,7 +848,7 @@
     "country:SV"
   ],
   [
-    "Sint Maarten (Dutch part)",
+    "Sint Maarten (Rhan Iseldiraidd)",
     "country:SX"
   ],
   [
@@ -852,19 +856,19 @@
     "country:SY"
   ],
   [
-    "Swaziland",
+    "Gwlad Swazi",
     "country:SZ"
   ],
   [
-    "Turks and Caicos Islands",
+    "Ynysoedd Turks a Caicos",
     "country:TC"
   ],
   [
-    "Chad",
+    "Tchad",
     "country:TD"
   ],
   [
-    "French Southern Territories",
+    "Tiriogaethau Deheuol Ffrainc",
     "country:TF"
   ],
   [
@@ -872,7 +876,7 @@
     "country:TG"
   ],
   [
-    "Thailand",
+    "Gwlad Thai",
     "country:TH"
   ],
   [
@@ -884,7 +888,7 @@
     "country:TK"
   ],
   [
-    "East Timor",
+    "Timor-Leste",
     "country:TL"
   ],
   [
@@ -900,11 +904,11 @@
     "country:TO"
   ],
   [
-    "Turkey",
+    "Twrci",
     "country:TR"
   ],
   [
-    "Trinidad and Tobago",
+    "Trinidad a Thobago",
     "country:TT"
   ],
   [
@@ -920,7 +924,7 @@
     "country:TZ"
   ],
   [
-    "Ukraine",
+    "Ukrain",
     "country:UA"
   ],
   [
@@ -928,11 +932,11 @@
     "country:UG"
   ],
   [
-    "United States Minor Outlying Islands",
+    "Mân Ynysoedd Pellennig yr Unol Daleithiau",
     "country:UM"
   ],
   [
-    "United States of America",
+    "Unol Daleithiau America",
     "country:US"
   ],
   [
@@ -944,11 +948,11 @@
     "country:UZ"
   ],
   [
-    "Vatican City",
+    "Dinas y Fatican",
     "country:VA"
   ],
   [
-    "Saint Vincent and the Grenadines",
+    "Saint Vincent a’r Grenadines",
     "country:VC"
   ],
   [
@@ -956,15 +960,15 @@
     "country:VE"
   ],
   [
-    "British Virgin Islands",
+    "Ynysoedd y Wyryf (Prydeinig)",
     "country:VG"
   ],
   [
-    "United States Virgin Islands",
+    "Ynysoedd y Wyryf (U.D.)",
     "country:VI"
   ],
   [
-    "Vietnam",
+    "Viet Nam",
     "country:VN"
   ],
   [
@@ -972,7 +976,7 @@
     "country:VU"
   ],
   [
-    "Wallis and Futuna",
+    "Wallis a Futuna",
     "country:WF"
   ],
   [
@@ -988,7 +992,7 @@
     "country:YT"
   ],
   [
-    "South Africa",
+    "De Affrica",
     "country:ZA"
   ],
   [

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -41,6 +41,9 @@ trait SpecBase extends PlaySpec
   with Mocked
   with FakeTrustsApp {
 
+  final val ENGLISH = "en"
+  final val WELSH = "cy"
+
   lazy val draftId: String = "draftId"
   lazy val userInternalId: String = "internalId"
   lazy val fakeDraftId: String = draftId

--- a/test/resources/countries-canonical-list-test-cy.json
+++ b/test/resources/countries-canonical-list-test-cy.json
@@ -1,0 +1,10 @@
+[
+  [
+    "Y Deyrnas Unedig",
+    "country:GB"
+  ],
+  [
+    "Sbaen",
+    "country:ES"
+  ]
+]

--- a/test/resources/countries-canonical-list-test.json
+++ b/test/resources/countries-canonical-list-test.json
@@ -1,0 +1,10 @@
+[
+  [
+    "United Kingdom",
+    "country:GB"
+  ],
+  [
+    "Spain",
+    "country:ES"
+  ]
+]

--- a/test/resources/non-uk-countries-canonical-list-test-cy.json
+++ b/test/resources/non-uk-countries-canonical-list-test-cy.json
@@ -1,0 +1,10 @@
+[
+  [
+    "Iwerddon",
+    "country:IE"
+  ],
+  [
+    "Gwlad Belg",
+    "country:BE"
+  ]
+]

--- a/test/resources/non-uk-countries-canonical-list-test.json
+++ b/test/resources/non-uk-countries-canonical-list-test.json
@@ -1,0 +1,10 @@
+[
+  [
+    "Ireland",
+    "country:IE"
+  ],
+  [
+    "Belgium",
+    "country:BE"
+  ]
+]

--- a/test/utils/countryOptions/CountryOptionsNonUKSpec.scala
+++ b/test/utils/countryOptions/CountryOptionsNonUKSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils.countryOptions
+
+import base.SpecBase
+import com.typesafe.config.ConfigException
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.i18n.{Lang, MessagesApi, MessagesImpl}
+import utils.InputOption
+
+class CountryOptionsNonUKSpec extends SpecBase with MockitoSugar {
+
+  "Country Options Non UK" must {
+
+    "build correctly the English InputOptions with non-UK country list and country code" in {
+
+      val application = applicationBuilder()
+        .configure(Map(
+          "location.canonical.list.all" -> "non-uk-countries-canonical-list-test.json"
+        ))
+        .build()
+
+      val messagesApi = app.injector.instanceOf[MessagesApi]
+      implicit val messages = MessagesImpl(lang = Lang(ENGLISH), messagesApi = messagesApi)
+
+      val countryOption: CountryOptions = application.injector.instanceOf[CountryOptionsNonUK]
+      countryOption.options mustEqual Seq(InputOption("BE", "Belgium"), InputOption("IE", "Ireland"))
+
+      application.stop()
+    }
+
+    "build correctly the Welsh InputOptions with non-UK country list and country code" in {
+
+      val application = applicationBuilder()
+        .configure(Map(
+          "location.canonical.list.allCY" -> "non-uk-countries-canonical-list-test-cy.json"
+        ))
+        .build()
+
+      val messagesApi = app.injector.instanceOf[MessagesApi]
+      implicit val messages = MessagesImpl(lang = Lang(WELSH), messagesApi = messagesApi)
+
+      val countryOption: CountryOptions = application.injector.instanceOf[CountryOptionsNonUK]
+      countryOption.options mustEqual Seq(InputOption("BE", "Gwlad Belg"), InputOption("IE", "Iwerddon"))
+
+      application.stop()
+    }
+
+    "throw the error if the country json does not exist" in {
+
+      val application = applicationBuilder()
+        .configure(Map(
+          "location.canonical.list.all" -> "countries-canonical-test.json"
+        ))
+        .build()
+
+      an[ConfigException.BadValue] shouldBe thrownBy {
+        application.injector.instanceOf[CountryOptions].options
+      }
+
+      application.stop()
+    }
+  }
+}
+
+
+

--- a/test/utils/countryOptions/CountryOptionsSpec.scala
+++ b/test/utils/countryOptions/CountryOptionsSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils.countryOptions
+
+import base.SpecBase
+import com.typesafe.config.ConfigException
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.i18n.{Lang, MessagesApi, MessagesImpl}
+import utils.InputOption
+
+class CountryOptionsSpec extends SpecBase with MockitoSugar {
+
+  "Country Options" must {
+
+    "build correctly the English InputOptions with all country list and country code" in {
+
+      val application = applicationBuilder()
+        .configure(Map(
+          "location.canonical.list.all" -> "countries-canonical-list-test.json"
+        ))
+        .build()
+
+      val messagesApi = app.injector.instanceOf[MessagesApi]
+      implicit val messages = MessagesImpl(lang = Lang(ENGLISH), messagesApi = messagesApi)
+
+      val countryOption: CountryOptions = application.injector.instanceOf[CountryOptions]
+      countryOption.options mustEqual Seq(InputOption("ES", "Spain"), InputOption("GB", "United Kingdom"))
+
+      application.stop()
+    }
+
+    "build correctly the Welsh InputOptions with all country list and country code" in {
+
+      val application = applicationBuilder()
+        .configure(Map(
+          "location.canonical.list.allCY" -> "countries-canonical-list-test-cy.json"
+        ))
+        .build()
+
+      val messagesApi = app.injector.instanceOf[MessagesApi]
+      implicit val messages = MessagesImpl(lang = Lang(WELSH), messagesApi = messagesApi)
+
+      val countryOption: CountryOptions = application.injector.instanceOf[CountryOptions]
+      countryOption.options mustEqual Seq(InputOption("ES", "Sbaen"), InputOption("GB", "Y Deyrnas Unedig"))
+
+      application.stop()
+    }
+
+    "throw the error if the country json does not exist" in {
+
+      val application = applicationBuilder()
+        .configure(Map(
+          "location.canonical.list.all" -> "countries-canonical-test.json"
+        ))
+        .build()
+
+      an[ConfigException.BadValue] shouldBe thrownBy {
+        application.injector.instanceOf[CountryOptions].options
+      }
+
+      application.stop()
+    }
+  }
+}

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -59,7 +59,7 @@ trait ViewBehaviours extends ViewSpecBase {
         "display language toggles" in {
 
           val doc = asDocument(view)
-          assertNotRenderedById(doc, "cymraeg-switch")
+          assertRenderedById(doc, "cymraeg-switch")
         }
 
       }
@@ -104,7 +104,7 @@ trait ViewBehaviours extends ViewSpecBase {
         "display language toggles" in {
 
           val doc = asDocument(view)
-          assertNotRenderedById(doc, "cymraeg-switch")
+          assertRenderedById(doc, "cymraeg-switch")
         }
 
       }
@@ -143,7 +143,7 @@ trait ViewBehaviours extends ViewSpecBase {
         "display language toggles" in {
 
           val doc = asDocument(view)
-          assertNotRenderedById(doc, "cymraeg-switch")
+          assertRenderedById(doc, "cymraeg-switch")
         }
 
       }


### PR DESCRIPTION
Simplify by having a english all countries json file & welsh all countries json file, filtering out "GB" for non-UK.
Check for selected language (messages.lang.code)
Add unit tests.