### PR TITLE
DDCE-3805: updated logic for country of residence and address questions

### DIFF
--- a/app/controllers/living_settlor/individual/SettlorIndividualAddressInternationalController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualAddressInternationalController.scala
@@ -21,8 +21,9 @@ import controllers.actions._
 import controllers.actions.living_settlor.individual.NameRequiredActionProvider
 import forms.InternationalAddressFormProvider
 import models.pages.InternationalAddress
+import models.requests.SettlorIndividualNameRequest
 import navigation.Navigator
-import pages.living_settlor.individual.{SettlorAddressInternationalPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAddressInternationalPage, SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import play.api.Logging
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -62,7 +63,7 @@ class SettlorIndividualAddressInternationalController @Inject()(
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, countryOptions.options, index, draftId, name))
+      Ok(view(preparedForm, countryOptions.options, index, draftId, name, settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = (actions.authWithData(draftId) andThen requireName(index, draftId)).async {
@@ -72,19 +73,25 @@ class SettlorIndividualAddressInternationalController @Inject()(
 
       form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, countryOptions.options, index, draftId, name))),
+          Future.successful(BadRequest(view(formWithErrors, countryOptions.options, index, draftId, name, settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(SettlorAddressInternationalPage(index), value) match {
             case Success(updatedAnswers) =>
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(SettlorAddressInternationalPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[SettlorIndividualAddressInternationalController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
         }
       )
+  }
+
+  private def settlorAliveAtRegistration(index: Int)(implicit request: SettlorIndividualNameRequest[AnyContent]): Boolean = {
+    request.userAnswers.get(SettlorAliveYesNoPage(index)) match {
+      case Some(value) => value
+      case None => false
+    }
   }
 }

--- a/app/controllers/living_settlor/individual/mld5/CountryOfResidencyYesNoController.scala
+++ b/app/controllers/living_settlor/individual/mld5/CountryOfResidencyYesNoController.scala
@@ -22,6 +22,7 @@ import controllers.actions.living_settlor.individual.NameRequiredActionProvider
 import forms.YesNoFormProvider
 import models.requests.SettlorIndividualNameRequest
 import navigation.Navigator
+import pages.living_settlor.individual.SettlorAliveYesNoPage
 import pages.living_settlor.individual.mld5.CountryOfResidencyYesNoPage
 import play.api.Logging
 import play.api.data.Form
@@ -48,7 +49,7 @@ class CountryOfResidencyYesNoController @Inject()(
                                                    technicalErrorView: TechnicalErrorView
                                                  )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging {
 
-  private val form: Form[Boolean] = yesNoFormProvider.withPrefix("settlorIndividualCountryOfResidencyYesNo")
+  private def form(messageKey: String): Form[Boolean] = yesNoFormProvider.withPrefix(messageKey)
 
   private def action(index: Int, draftId: String): ActionBuilder[SettlorIndividualNameRequest, AnyContent] = {
     actions.authWithData(draftId) andThen requireName(index, draftId)
@@ -57,32 +58,44 @@ class CountryOfResidencyYesNoController @Inject()(
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = action(index, draftId) {
     implicit request =>
 
+      val messageKeyPrefix =
+        if(settlorAliveAtRegistration(index)) "settlorIndividualCountryOfResidencyYesNo" else "settlorIndividualCountryOfResidencyYesNoPastTense"
+
       val preparedForm = request.userAnswers.get(CountryOfResidencyYesNoPage(index)) match {
-        case None => form
-        case Some(value) => form.fill(value)
+        case None => form(messageKeyPrefix)
+        case Some(value) => form(messageKeyPrefix).fill(value)
       }
 
-      Ok(view(preparedForm, index, draftId, request.name))
+      Ok(view(preparedForm, index, draftId, request.name, settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = action(index, draftId).async {
     implicit request =>
 
-      form.bindFromRequest().fold(
+      val messageKeyPrefix =
+        if(settlorAliveAtRegistration(index)) "settlorIndividualCountryOfResidencyYesNo" else "settlorIndividualCountryOfResidencyYesNoPastTense"
+
+      form(messageKeyPrefix).bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, index, draftId, request.name))),
+          Future.successful(BadRequest(view(formWithErrors, index, draftId, request.name, settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(CountryOfResidencyYesNoPage(index), value) match {
             case Success(updatedAnswers) =>
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(CountryOfResidencyYesNoPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[CountryOfResidencyYesNoController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
         }
       )
+  }
+
+  private def settlorAliveAtRegistration(index: Int)(implicit request: SettlorIndividualNameRequest[AnyContent]): Boolean = {
+    request.userAnswers.get(SettlorAliveYesNoPage(index)) match {
+      case Some(value) => value
+      case None => false
+    }
   }
 }

--- a/app/controllers/living_settlor/individual/mld5/UkCountryOfResidencyYesNoController.scala
+++ b/app/controllers/living_settlor/individual/mld5/UkCountryOfResidencyYesNoController.scala
@@ -22,6 +22,7 @@ import controllers.actions.living_settlor.individual.NameRequiredActionProvider
 import forms.YesNoFormProvider
 import models.requests.SettlorIndividualNameRequest
 import navigation.Navigator
+import pages.living_settlor.individual.SettlorAliveYesNoPage
 import pages.living_settlor.individual.mld5.UkCountryOfResidencyYesNoPage
 import play.api.Logging
 import play.api.data.Form
@@ -48,7 +49,7 @@ class UkCountryOfResidencyYesNoController @Inject()(
                                                      technicalErrorView: TechnicalErrorView
                                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging{
 
-  private val form: Form[Boolean] = yesNoFormProvider.withPrefix("settlorIndividualUkCountryOfResidencyYesNo")
+  private def form(messageKey: String): Form[Boolean] = yesNoFormProvider.withPrefix(messageKey)
 
   private def action(index: Int, draftId: String): ActionBuilder[SettlorIndividualNameRequest, AnyContent] = {
     actions.authWithData(draftId) andThen requireName(index, draftId)
@@ -57,32 +58,45 @@ class UkCountryOfResidencyYesNoController @Inject()(
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = action(index, draftId) {
     implicit request =>
 
+      val messageKeyPrefix =
+        if(settlorAliveAtRegistration(index)) "settlorIndividualUkCountryOfResidencyYesNo"else "settlorIndividualUkCountryOfResidencyYesNoPastTense"
+
       val preparedForm = request.userAnswers.get(UkCountryOfResidencyYesNoPage(index)) match {
-        case None => form
-        case Some(value) => form.fill(value)
+        case None => form(messageKeyPrefix)
+        case Some(value) => form(messageKeyPrefix).fill(value)
       }
 
-      Ok(view(preparedForm, index, draftId, request.name))
+      Ok(view(preparedForm, index, draftId, request.name, settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = action(index, draftId).async {
     implicit request =>
 
-      form.bindFromRequest().fold(
+      val messageKeyPrefix =
+        if(settlorAliveAtRegistration(index)) "settlorIndividualUkCountryOfResidencyYesNo"else "settlorIndividualUkCountryOfResidencyYesNoPastTense"
+
+      form(messageKeyPrefix).bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, index, draftId, request.name))),
+          Future.successful(BadRequest(view(formWithErrors, index, draftId, request.name, settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(UkCountryOfResidencyYesNoPage(index), value) match {
             case Success(updatedAnswers) =>
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(UkCountryOfResidencyYesNoPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[UkCountryOfResidencyYesNoController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
         }
       )
   }
+
+  private def settlorAliveAtRegistration(index: Int)(implicit request: SettlorIndividualNameRequest[AnyContent]): Boolean = {
+    request.userAnswers.get(SettlorAliveYesNoPage(index)) match {
+      case Some(value) => value
+      case None => false
+    }
+  }
+
 }

--- a/app/views/living_settlor/individual/SettlorIndividualAddressInternationalView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualAddressInternationalView.scala.html
@@ -27,10 +27,19 @@
     internationalAddress: InternationalAddress
 )
 
-@(form: Form[_], countryOptions:Seq[InputOption], index:Int, draftId: String, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], countryOptions:Seq[InputOption], index:Int, draftId: String, name: FullName,
+settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualAddressInternationalPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualAddressInternational"
+    } else {
+        "settlorIndividualAddressInternationalPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualAddressInternational.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualAddressInternationalPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -40,7 +49,7 @@
 
         @internationalAddress(
             form = form,
-            legend = messages("settlorIndividualAddressInternational.heading", name.toString),
+            legend = messages(s"${settlorIndividualAddressInternationalPrefix}.heading", name.toString),
             legendAsHeading = true,
             countryOptions = countryOptions
         )

--- a/app/views/living_settlor/individual/SettlorIndividualAddressUKView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualAddressUKView.scala.html
@@ -26,10 +26,18 @@
     ukAddress: UkAddress
 )
 
-@(form: Form[_], draftId: String, index: Int, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], draftId: String, index: Int, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualAddressUKPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualAddressUK"
+    } else {
+        "settlorIndividualAddressUKPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualAddressUK.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualAddressUKPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -37,7 +45,7 @@
 
         @error_summary(form.errors)
 
-        @ukAddress(form, messages("settlorIndividualAddressUK.heading", name.toString))
+        @ukAddress(form, messages(s"${settlorIndividualAddressUKPrefix}.heading", name.toString))
 
         @submitButton()
     }

--- a/app/views/living_settlor/individual/SettlorIndividualAddressUKYesNoView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualAddressUKYesNoView.scala.html
@@ -26,10 +26,18 @@
     inputYesNo: InputYesNo
 )
 
-@(form: Form[_], draftId: String, index: Int, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], draftId: String, index: Int, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualAddressUKYesNoPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualAddressUKYesNo"
+    } else {
+        "settlorIndividualAddressUKYesNoPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualAddressUKYesNo.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualAddressUKYesNoPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +47,7 @@
 
         @inputYesNo(
             field = form("value"),
-            label = messages("settlorIndividualAddressUKYesNo.heading", name),
+            label = messages(s"${settlorIndividualAddressUKYesNoPrefix}.heading", name),
             legendClass = Some("govuk-heading-l"),
             legendAsHeading = true
         )

--- a/app/views/living_settlor/individual/SettlorIndividualAddressYesNoView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualAddressYesNoView.scala.html
@@ -26,10 +26,18 @@
     inputYesNo: InputYesNo
 )
 
-@(form: Form[_], draftId: String, index: Int, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], draftId: String, index: Int, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualAddressYesNoPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualAddressYesNo"
+    } else {
+        "settlorIndividualAddressYesNoPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualAddressYesNo.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualAddressYesNoPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +47,7 @@
 
         @inputYesNo(
             field = form("value"),
-            label = messages("settlorIndividualAddressYesNo.heading", name.toString),
+            label = messages(s"${settlorIndividualAddressYesNoPrefix}.heading", name.toString),
             legendClass = Some("govuk-heading-l"),
             legendAsHeading = true
         )

--- a/app/views/living_settlor/individual/mld5/CountryOfResidencyView.scala.html
+++ b/app/views/living_settlor/individual/mld5/CountryOfResidencyView.scala.html
@@ -27,10 +27,19 @@
     select: InputSelect
 )
 
-@(form: Form[_], index: Int, draftId: String, countryOptions: Seq[InputOption], name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], index: Int, draftId: String, countryOptions: Seq[InputOption], name: FullName,
+settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualCountryOfResidencyPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualCountryOfResidency"
+    } else {
+        "settlorIndividualCountryOfResidencyPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualCountryOfResidency.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualCountryOfResidencyPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +48,7 @@
         @error_summary(form.errors)
 
         @select(field = form("value"),
-            label = messages("settlorIndividualCountryOfResidency.heading", name.toString),
+            label = messages(s"${settlorIndividualCountryOfResidencyPrefix}.heading", name.toString),
             labelClasses = Set("govuk-heading-l"),
             labelAsHeading = true,
             options = countryOptions,

--- a/app/views/living_settlor/individual/mld5/CountryOfResidencyYesNoView.scala.html
+++ b/app/views/living_settlor/individual/mld5/CountryOfResidencyYesNoView.scala.html
@@ -26,10 +26,18 @@
     inputYesNo: InputYesNo
 )
 
-@(form: Form[_], index: Int, draftId: String, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], index: Int, draftId: String, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualCountryOfResidencyYesNoPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualCountryOfResidencyYesNo"
+    } else {
+        "settlorIndividualCountryOfResidencyYesNoPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualCountryOfResidencyYesNo.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualCountryOfResidencyYesNoPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,9 +47,9 @@
 
         @inputYesNo(
             field = form("value"),
-            label = messages("settlorIndividualCountryOfResidencyYesNo.heading", name.toString),
+            label = messages(s"${settlorIndividualCountryOfResidencyYesNoPrefix}.heading", name.toString),
             legendClass = Some("govuk-heading-l"),
-            hint = Some(messages("settlorIndividualCountryOfResidencyYesNo.hint"))
+            hint = Some(messages(s"${settlorIndividualCountryOfResidencyYesNoPrefix}.hint"))
         )
 
         @submitButton()

--- a/app/views/living_settlor/individual/mld5/UkCountryOfResidencyYesNoView.scala.html
+++ b/app/views/living_settlor/individual/mld5/UkCountryOfResidencyYesNoView.scala.html
@@ -26,10 +26,18 @@
     inputYesNo: InputYesNo
 )
 
-@(form: Form[_], index: Int, draftId: String, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], index: Int, draftId: String, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualUkCountryOfResidencyYesNoPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualUkCountryOfResidencyYesNo"
+    } else {
+        "settlorIndividualUkCountryOfResidencyYesNoPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualUkCountryOfResidencyYesNo.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualUkCountryOfResidencyYesNoPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +47,7 @@
 
         @inputYesNo(
             field = form("value"),
-            label = messages("settlorIndividualUkCountryOfResidencyYesNo.heading", name.toString),
+            label = messages(s"${settlorIndividualUkCountryOfResidencyYesNoPrefix}.heading", name.toString),
             legendClass = Some("govuk-heading-l")
         )
 

--- a/conf/messages
+++ b/conf/messages
@@ -362,10 +362,21 @@ settlorIndividualCountryOfResidencyYesNo.checkYourAnswersLabel = Do you know {0}
 settlorIndividualCountryOfResidencyYesNo.hint = The country of residence is usually where the settlor lives and works most of the time during the tax year.
 settlorIndividualCountryOfResidencyYesNo.error.required = Select yes if you know the settlor’s country of residence
 
+settlorIndividualCountryOfResidencyYesNoPastTense.title = Do you know the settlor’s last known country of residence?
+settlorIndividualCountryOfResidencyYesNoPastTense.heading = Do you know {0}’s last known country of residence?
+settlorIndividualCountryOfResidencyYesNoPastTense.checkYourAnswersLabel = Do you know {0}’s last known country of residence?
+settlorIndividualCountryOfResidencyYesNoPastTense.hint = The last known country of residence is usually where the settlor lived and worked most of the time during the tax year.
+settlorIndividualCountryOfResidencyYesNoPastTense.error.required = Select yes if you know the settlor’s last known country of residence
+
 settlorIndividualUkCountryOfResidencyYesNo.title = Is the settlor a UK resident?
 settlorIndividualUkCountryOfResidencyYesNo.heading = Is {0} a UK resident?
 settlorIndividualUkCountryOfResidencyYesNo.checkYourAnswersLabel = Is {0} a UK resident?
 settlorIndividualUkCountryOfResidencyYesNo.error.required = Select yes if the settlor is a UK resident
+
+settlorIndividualUkCountryOfResidencyYesNoPastTense.title = Was the settlor a UK resident?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.heading = Was {0} a UK resident?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.checkYourAnswersLabel = Was {0} a UK resident?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.error.required = Select yes if the settlor was a UK resident
 
 settlorIndividualCountryOfResidency.title = What is the settlor’s country of residence?
 settlorIndividualCountryOfResidency.heading = What is {0}’s country of residence?
@@ -373,6 +384,13 @@ settlorIndividualCountryOfResidency.checkYourAnswersLabel = What is {0}’s coun
 settlorIndividualCountryOfResidency.error.required = Enter a country
 settlorIndividualCountryOfResidency.error.length = The country of residence must be 100 characters or less
 settlorIndividualCountryOfResidency.error.invalidCharacters = The country of residence must only include letters a to z, apostrophes, commas, full stops, hyphens, round brackets and spaces
+
+settlorIndividualCountryOfResidencyPastTense.title = What was the settlor’s country of residence?
+settlorIndividualCountryOfResidencyPastTense.heading = What was {0}’s country of residence?
+settlorIndividualCountryOfResidencyPastTense.checkYourAnswersLabel = What is {0}’s country of residence?
+settlorIndividualCountryOfResidencyPastTense.error.required = Enter a country
+settlorIndividualCountryOfResidencyPastTense.error.length = The country of residence must be 100 characters or less
+settlorIndividualCountryOfResidencyPastTense.error.invalidCharacters = The country of residence must only include letters a to z, apostrophes, commas, full stops, hyphens, round brackets and spaces
 
 settlorIndividualMentalCapacityYesNo.title = Does the settlor have mental capacity at the time of registration?
 settlorIndividualMentalCapacityYesNo.heading = Does {0} have mental capacity at the time of registration?
@@ -399,6 +417,11 @@ settlorIndividualAddressYesNo.heading = Do you know {0}’s address?
 settlorIndividualAddressYesNo.checkYourAnswersLabel = Do you know {0}’s address?
 settlorIndividualAddressYesNo.error.required = Select yes if you know the settlor’s address
 
+settlorIndividualAddressYesNoPastTense.title = Do you know the settlor’s last known address?
+settlorIndividualAddressYesNoPastTense.heading = Do you know {0}’s last known address?
+settlorIndividualAddressYesNoPastTense.checkYourAnswersLabel = Do you know {0}’s last known address?
+settlorIndividualAddressYesNoPastTense.error.required = Select yes if you know the settlor’s last known address
+
 settlorIndividualNINO.title = What is the settlor’s National Insurance number?
 settlorIndividualNINO.heading = What is {0}’s National Insurance number?
 settlorIndividualNINO.checkYourAnswersLabel = What is {0}’s National Insurance number?
@@ -416,14 +439,27 @@ settlorIndividualAddressInternational.title = What is the settlor’s address?
 settlorIndividualAddressInternational.heading = What is {0}’s address?
 settlorIndividualAddressInternational.checkYourAnswersLabel = What is {0}’s address?
 
+settlorIndividualAddressInternationalPastTense.title = What is the settlor’s last known address?
+settlorIndividualAddressInternationalPastTense.heading = What is {0}’s last known address?
+settlorIndividualAddressInternationalPastTense.checkYourAnswersLabel = What is {0}’s last known address?
+
 settlorIndividualAddressUK.title = What is the settlor’s address?
 settlorIndividualAddressUK.heading = What is {0}’s address?
 settlorIndividualAddressUK.checkYourAnswersLabel = What is {0}’s address?
+
+settlorIndividualAddressUKPastTense.title = What is the settlor’s last known address?
+settlorIndividualAddressUKPastTense.heading = What is {0}’s last known address?
+settlorIndividualAddressUKPastTense.checkYourAnswersLabel = What is {0}’s last known address?
 
 settlorIndividualAddressUKYesNo.title = Does the settlor live in the UK?
 settlorIndividualAddressUKYesNo.heading = Does {0} live in the UK?
 settlorIndividualAddressUKYesNo.checkYourAnswersLabel = Does {0} live in the UK?
 settlorIndividualAddressUKYesNo.error.required = Select yes if the settlor lives in the UK
+
+settlorIndividualAddressUKYesNoPastTense.title = Was the settlor’s last known address in the UK?
+settlorIndividualAddressUKYesNoPastTense.heading = Was {0} last known address in the UK?
+settlorIndividualAddressUKYesNoPastTense.checkYourAnswersLabel = Was {0} last known address in the UK?
+settlorIndividualAddressUKYesNoPastTense.error.required = Select yes if the settlor’s last known address was in the UK
 
 settlorIndividualIDCard.title = What are the settlor’s ID card details?
 settlorIndividualIDCard.heading = What are {0}’s ID card details?

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -331,19 +331,37 @@ settlorIndividualAddressInternational.checkYourAnswersLabel = Beth yw cyfeiriad 
 settlorIndividualAddressInternational.heading = Beth yw cyfeiriad {0}?
 settlorIndividualAddressInternational.title = Beth yw cyfeiriad y setlwr?
 
+settlorIndividualAddressInternationalPastTense.title = What is the settlor’s last known address?
+settlorIndividualAddressInternationalPastTense.heading = What is {0}’s last known address?
+settlorIndividualAddressInternationalPastTense.checkYourAnswersLabel = What is {0}’s last known address?
+
 settlorIndividualAddressUK.checkYourAnswersLabel = Beth yw cyfeiriad {0}?
 settlorIndividualAddressUK.heading = Beth yw cyfeiriad {0}?
 settlorIndividualAddressUK.title = Beth yw cyfeiriad y setlwr?
+
+settlorIndividualAddressUKPastTense.title = What is the settlor’s last known address?
+settlorIndividualAddressUKPastTense.heading = What is {0}’s last known address?
+settlorIndividualAddressUKPastTense.checkYourAnswersLabel = What is {0}’s last known address?
 
 settlorIndividualAddressUKYesNo.checkYourAnswersLabel = A yw {0} yn byw yn y DU?
 settlorIndividualAddressUKYesNo.error.required = Dewiswch ‘Iawn’ os yw’r setlwr yn byw yn y DU
 settlorIndividualAddressUKYesNo.heading = A yw {0} yn byw yn y DU?
 settlorIndividualAddressUKYesNo.title = A yw’r setlwr yn byw yn y DU?
 
+settlorIndividualAddressUKYesNoPastTense.title = Was the settlor’s last known address in the UK?
+settlorIndividualAddressUKYesNoPastTense.heading = Was {0} last known address in the UK?
+settlorIndividualAddressUKYesNoPastTense.checkYourAnswersLabel = Was {0} last known address in the UK?
+settlorIndividualAddressUKYesNoPastTense.error.required = Select yes if the settlor’s last known address was in the UK
+
 settlorIndividualAddressYesNo.checkYourAnswersLabel = A ydych yn gwybod cyfeiriad {0}?
 settlorIndividualAddressYesNo.error.required = Dewiswch ‘Iawn’ os ydych yn gwybod cyfeiriad y setlwr
 settlorIndividualAddressYesNo.heading = A ydych yn gwybod cyfeiriad {0}?
 settlorIndividualAddressYesNo.title = A ydych yn gwybod cyfeiriad y setlwr?
+
+settlorIndividualAddressYesNoPastTense.title = Do you know the settlor’s last known address?
+settlorIndividualAddressYesNoPastTense.heading = Do you know {0}’s last known address?
+settlorIndividualAddressYesNoPastTense.checkYourAnswersLabel = Do you know {0}’s last known address?
+settlorIndividualAddressYesNoPastTense.error.required = Select yes if you know the settlor’s last known address
 
 settlorIndividualCountryOfNationality.checkYourAnswersLabel = Beth yw gwlad cenedligrwydd {0}?
 settlorIndividualCountryOfNationality.error.invalidCharacters = Mae’n rhaid i wlad y cenedligrwydd gynnwys y llythrennau a i z yn unig
@@ -365,11 +383,24 @@ settlorIndividualCountryOfResidency.error.required = Nodwch wlad
 settlorIndividualCountryOfResidency.heading = Beth yw gwlad breswyl {0}?
 settlorIndividualCountryOfResidency.title = Beth yw gwlad breswyl y setlwr?
 
+settlorIndividualCountryOfResidencyPastTense.title = What was the settlor’s country of residence?
+settlorIndividualCountryOfResidencyPastTense.heading = What was {0}’s country of residence?
+settlorIndividualCountryOfResidencyPastTense.checkYourAnswersLabel = What is {0}’s country of residence?
+settlorIndividualCountryOfResidencyPastTense.error.required = Enter a country
+settlorIndividualCountryOfResidencyPastTense.error.length = The country of residence must be 100 characters or less
+settlorIndividualCountryOfResidencyPastTense.error.invalidCharacters = The country of residence must only include letters a to z, apostrophes, commas, full stops, hyphens, round brackets and spaces
+
 settlorIndividualCountryOfResidencyYesNo.checkYourAnswersLabel = A ydych yn gwybod gwlad breswyl {0}?
 settlorIndividualCountryOfResidencyYesNo.error.required = Dewiswch ‘Iawn’ os ydych yn gwybod gwlad breswyl y setlwr
 settlorIndividualCountryOfResidencyYesNo.heading = A ydych yn gwybod gwlad breswyl {0}?
 settlorIndividualCountryOfResidencyYesNo.hint = Fel arfer, y wlad breswyl yw lle mae’r setlwr yn byw ac yn gweithio’r rhan fwyaf o’r amser yn ystod y flwyddyn dreth.
 settlorIndividualCountryOfResidencyYesNo.title = A ydych yn gwybod gwlad breswyl y setlwr?
+
+settlorIndividualCountryOfResidencyYesNoPastTense.title = Do you know the settlor’s last known country of residence?
+settlorIndividualCountryOfResidencyYesNoPastTense.heading = Do you know {0}’s last known country of residence?
+settlorIndividualCountryOfResidencyYesNoPastTense.checkYourAnswersLabel = Do you know {0}’s last known country of residence?
+settlorIndividualCountryOfResidencyYesNoPastTense.hint = The last known country of residence is usually where the settlor lived and worked most of the time during the tax year.
+settlorIndividualCountryOfResidencyYesNoPastTense.error.required = Select yes if you know the settlor’s last known country of residence
 
 settlorIndividualDateOfBirth.checkYourAnswersLabel = Beth yw dyddiad geni {0}?
 settlorIndividualDateOfBirth.heading = Beth yw dyddiad geni {0}?
@@ -492,6 +523,11 @@ settlorIndividualUkCountryOfResidencyYesNo.checkYourAnswersLabel = A yw {0} yn b
 settlorIndividualUkCountryOfResidencyYesNo.error.required = Dewiswch ‘Iawn’ os yw’r setlwr yn breswylydd yn y DU
 settlorIndividualUkCountryOfResidencyYesNo.heading = A yw {0} yn breswylydd yn y DU?
 settlorIndividualUkCountryOfResidencyYesNo.title = A yw’r setlwr yn breswylydd yn y DU?
+
+settlorIndividualUkCountryOfResidencyYesNoPastTense.title = Was the settlor a UK resident?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.heading = Was {0} a UK resident?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.checkYourAnswersLabel = Was {0} a UK resident?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.error.required = Select yes if the settlor was a UK resident
 
 settlorInfo.bulletpoint1 = dyddiad y farwolaeth
 settlorInfo.bulletpoint10 = a oedd y busnes wedi bodoli am o leiaf 2 flynedd pan ychwanegwyd unrhyw ased at yr ymddiriedolaeth

--- a/test/controllers/living_settlor/individual/SettlorIndividualAddressInternationalControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorIndividualAddressInternationalControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes._
 import forms.InternationalAddressFormProvider
 import models.UserAnswers
 import models.pages.{FullName, InternationalAddress}
-import pages.living_settlor.individual.{SettlorAddressInternationalPage, SettlorIndividualNINOPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAddressInternationalPage, SettlorAliveYesNoPage, SettlorIndividualNINOPage, SettlorIndividualNamePage}
 import play.api.Application
 import play.api.data.Form
 import play.api.mvc.{Call, Result}
@@ -35,14 +35,14 @@ import scala.concurrent.Future
 
 class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
 
-  def onwardRoute = Call("GET", "/foo")
+  private def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new InternationalAddressFormProvider()
-  val form: Form[InternationalAddress] = formProvider()
-  val index = 0
-  val name = FullName("First", Some("Middle"), "Last")
+  private val formProvider = new InternationalAddressFormProvider()
+  private val form: Form[InternationalAddress] = formProvider()
+  private val index = 0
+  private val name = FullName("First", Some("Middle"), "Last")
 
-  lazy val settlorIndividualAddressInternationalRoute: String = routes.SettlorIndividualAddressInternationalController.onPageLoad(index, fakeDraftId).url
+  private lazy val settlorIndividualAddressInternationalRoute: String = routes.SettlorIndividualAddressInternationalController.onPageLoad(index, fakeDraftId).url
 
 
   "SettlorIndividualAddressInternational Controller" must {
@@ -64,14 +64,15 @@ class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, countryOptions, index, fakeDraftId, name)(request, messages).toString
+        view(form, countryOptions, index, fakeDraftId, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressInternationalPage(index), InternationalAddress("line 1", "line 2", Some("line 3"), "country")).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -87,14 +88,16 @@ class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(InternationalAddress("line 1", "line 2", Some("line 3"), "country")), countryOptions, index, fakeDraftId, name)(request, messages).toString
+        view(form.fill(InternationalAddress("line 1", "line 2", Some("line 3"), "country")), countryOptions, index,
+          fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressInternationalPage(index), InternationalAddress("line 1", "line 2", Some("line 3"), "country")).success.value
 
       val application =
@@ -115,7 +118,7 @@ class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
 
     "redirect to Settlors Name page when Settlors name is not answered" in {
 
-      val userAnswers = emptyUserAnswers
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
         .set(SettlorIndividualNINOPage(index), "CC123456A").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -133,7 +136,8 @@ class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -152,7 +156,7 @@ class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, countryOptions, index, fakeDraftId, name)(request, messages).toString
+        view(boundForm, countryOptions, index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/SettlorIndividualAddressUKControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorIndividualAddressUKControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.routes._
 import forms.UKAddressFormProvider
 import models.pages.{FullName, UKAddress}
-import pages.living_settlor.individual.{SettlorAddressUKPage, SettlorIndividualNINOPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAddressUKPage, SettlorAliveYesNoPage, SettlorIndividualNINOPage, SettlorIndividualNamePage}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -28,14 +28,14 @@ import views.html.living_settlor.individual.SettlorIndividualAddressUKView
 
 class SettlorIndividualAddressUKControllerSpec extends SpecBase {
 
-  def onwardRoute = Call("GET", "/foo")
+  private def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new UKAddressFormProvider()
-  val form = formProvider()
-  val index = 0
-  val name = FullName("First", Some("Middle"), "Last")
+  private val formProvider = new UKAddressFormProvider()
+  private val form = formProvider()
+  private val index = 0
+  private val name = FullName("First", Some("Middle"), "Last")
 
-  lazy val settlorIndividualAddressUKRoute: String = routes.SettlorIndividualAddressUKController.onPageLoad(index, fakeDraftId).url
+  private lazy val settlorIndividualAddressUKRoute: String = routes.SettlorIndividualAddressUKController.onPageLoad(index, fakeDraftId).url
 
   "SettlorIndividualAddressUK Controller" must {
 
@@ -54,14 +54,15 @@ class SettlorIndividualAddressUKControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, fakeDraftId, index, name)(request, messages).toString
+        view(form, fakeDraftId, index, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressUKPage(index), UKAddress("line 1", "line 2", Some("line 3"), Some("line 4"), "line 5")).success.value
 
       val application = applicationBuilder(Some(userAnswers)).build()
@@ -75,14 +76,16 @@ class SettlorIndividualAddressUKControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(UKAddress("line 1", "line 2", Some("line 3"), Some("line 4"), "line 5")), fakeDraftId, index, name)(request, messages).toString
+        view(form.fill(UKAddress("line 1", "line 2", Some("line 3"), Some("line 4"), "line 5")), fakeDraftId, index,
+          name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressUKPage(index), UKAddress("line 1", "line 2", Some("line 3"), Some("line 4"), "line 5")).success.value
 
       val application =
@@ -103,7 +106,7 @@ class SettlorIndividualAddressUKControllerSpec extends SpecBase {
 
     "redirect to Settlors Name page when Settlors name is not answered" in {
 
-      val userAnswers = emptyUserAnswers
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
         .set(SettlorIndividualNINOPage(index), "CC123456A").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -121,8 +124,8 @@ class SettlorIndividualAddressUKControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index),
-        name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -139,7 +142,7 @@ class SettlorIndividualAddressUKControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, fakeDraftId, index, name)(request, messages).toString
+        view(boundForm, fakeDraftId, index, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/SettlorIndividualAddressUKYesNoControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorIndividualAddressUKYesNoControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.routes._
 import forms.YesNoFormProvider
 import models.pages.FullName
-import pages.living_settlor.individual.{SettlorAddressUKYesNoPage, SettlorIndividualDateOfBirthYesNoPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAddressUKYesNoPage, SettlorAliveYesNoPage, SettlorIndividualDateOfBirthYesNoPage, SettlorIndividualNamePage}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -28,20 +28,22 @@ import views.html.living_settlor.individual.SettlorIndividualAddressUKYesNoView
 
 class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
 
-  def onwardRoute = Call("GET", "/foo")
+  private def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new YesNoFormProvider()
-  val form = formProvider.withPrefix("settlorIndividualAddressUKYesNo")
-  val index = 0
-  val name = FullName("First", Some("Middle"), "Last")
+  private val formProvider = new YesNoFormProvider()
+  private val form = formProvider.withPrefix("settlorIndividualAddressUKYesNo")
+  private val index = 0
+  private val name = FullName("First", Some("Middle"), "Last")
 
-  lazy val settlorIndividualAddressUKYesNoRoute = routes.SettlorIndividualAddressUKYesNoController.onPageLoad(index, fakeDraftId).url
+  private lazy val settlorIndividualAddressUKYesNoRoute = routes.SettlorIndividualAddressUKYesNoController.onPageLoad(index, fakeDraftId).url
 
   "SettlorIndividualAddressUKYesNo Controller" must {
 
     "return OK and the correct view for a GET" in {
+      val formContentInPastTense = formProvider.withPrefix("settlorIndividualAddressUKYesNoPastTense")
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers
+        .set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -54,14 +56,15 @@ class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, fakeDraftId, index, name)(request, messages).toString
+        view(formContentInPastTense, fakeDraftId, index, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressUKYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -75,14 +78,15 @@ class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(true), fakeDraftId, index, name)(request, messages).toString
+        view(form.fill(true), fakeDraftId, index, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -101,7 +105,8 @@ class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressUKYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -119,7 +124,7 @@ class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, fakeDraftId, index, name)(request, messages).toString
+        view(boundForm, fakeDraftId, index, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
@@ -127,6 +132,7 @@ class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
     "redirect to Settlors Name page when Settlors name is not answered" in {
 
       val userAnswers = emptyUserAnswers
+        .set(SettlorAliveYesNoPage(index), true).success.value
         .set(SettlorIndividualDateOfBirthYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()

--- a/test/controllers/living_settlor/individual/SettlorIndividualAddressYesNoControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorIndividualAddressYesNoControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.routes._
 import forms.YesNoFormProvider
 import models.pages.FullName
-import pages.living_settlor.individual.{SettlorAddressYesNoPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAddressYesNoPage, SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import views.html.living_settlor.individual.SettlorIndividualAddressYesNoView
@@ -37,6 +37,7 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
   "SettlorIndividualAddressYesNo Controller" must {
 
     "return OK and the correct view for a GET" in {
+      val formContentInPastTense = formProvider.withPrefix("settlorIndividualAddressYesNoPastTense")
 
       val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
 
@@ -51,14 +52,15 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, fakeDraftId, index, name)(request, messages).toString
+        view(formContentInPastTense, fakeDraftId, index, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -72,14 +74,15 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(true), fakeDraftId, index, name)(request, messages).toString
+        view(form.fill(true), fakeDraftId, index, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -99,7 +102,7 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
 
     "redirect to Settlors Name page when Settlors name is not answered" in {
 
-      val userAnswers = emptyUserAnswers
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
         .set(SettlorAddressYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -117,8 +120,8 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index),
-        name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -135,7 +138,7 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, fakeDraftId, index, name)(request, messages).toString
+        view(boundForm, fakeDraftId, index, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/mld5/CountryOfResidencyControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/mld5/CountryOfResidencyControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.routes._
 import forms.CountryFormProvider
 import models.UserAnswers
 import models.pages.FullName
-import pages.living_settlor.individual.SettlorIndividualNamePage
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import pages.living_settlor.individual.mld5.CountryOfResidencyPage
 import play.api.data.Form
 import play.api.test.FakeRequest
@@ -45,13 +45,16 @@ class CountryOfResidencyControllerSpec extends SpecBase {
   private val validAnswer: String = "France"
   private val validFormAnswer: String = "FR"
 
-  private val baseAnswers: UserAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+  private val baseAnswers: UserAnswers = emptyUserAnswers
+    .set(SettlorAliveYesNoPage(index), true).success.value
+    .set(SettlorIndividualNamePage(index), name).success.value
 
   "CountryOfResidency Controller" must {
 
     "return OK and the correct view for a GET" in {
+      val formContentInPastTense: Form[String] = formProvider.withPrefix("settlorIndividualCountryOfResidencyPastTense")
 
-      val userAnswers = baseAnswers
+      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -64,7 +67,7 @@ class CountryOfResidencyControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, index, fakeDraftId, countryOptions, name)(request, messages).toString
+        view(formContentInPastTense, index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
@@ -85,7 +88,7 @@ class CountryOfResidencyControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(validAnswer), index, fakeDraftId, countryOptions, name)(request, messages).toString
+        view(form.fill(validAnswer), index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
@@ -126,7 +129,7 @@ class CountryOfResidencyControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, index, fakeDraftId, countryOptions, name)(request, messages).toString
+        view(boundForm, index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/mld5/CountryOfResidencyYesNoControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/mld5/CountryOfResidencyYesNoControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.routes._
 import forms.YesNoFormProvider
 import models.UserAnswers
 import models.pages.FullName
-import pages.living_settlor.individual.SettlorIndividualNamePage
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import pages.living_settlor.individual.mld5.CountryOfResidencyYesNoPage
 import play.api.data.Form
 import play.api.test.FakeRequest
@@ -40,13 +40,17 @@ class CountryOfResidencyYesNoControllerSpec extends SpecBase {
 
   private val validAnswer: Boolean = true
 
-  private val baseAnswers: UserAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+  private val baseAnswers: UserAnswers = emptyUserAnswers
+    .set(SettlorAliveYesNoPage(index), true).success.value
+    .set(SettlorIndividualNamePage(index), name).success.value
 
   "CountryOfResidencyYesNo Controller" must {
 
     "return OK and the correct view for a GET" in {
 
-      val userAnswers = baseAnswers
+      val formContentInPastTense: Form[Boolean] = formProvider.withPrefix("settlorIndividualCountryOfResidencyYesNoPastTense")
+
+      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -59,7 +63,7 @@ class CountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, index, fakeDraftId, name)(request, messages).toString
+        view(formContentInPastTense, index, fakeDraftId, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
@@ -80,7 +84,7 @@ class CountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(validAnswer), index, fakeDraftId, name)(request, messages).toString
+        view(form.fill(validAnswer), index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
@@ -121,7 +125,7 @@ class CountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, index, fakeDraftId, name)(request, messages).toString
+        view(boundForm, index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/mld5/UkCountryOfResidencyYesNoControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/mld5/UkCountryOfResidencyYesNoControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.routes._
 import forms.YesNoFormProvider
 import models.UserAnswers
 import models.pages.FullName
-import pages.living_settlor.individual.SettlorIndividualNamePage
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import pages.living_settlor.individual.mld5.UkCountryOfResidencyYesNoPage
 import play.api.data.Form
 import play.api.test.FakeRequest
@@ -40,13 +40,17 @@ class UkCountryOfResidencyYesNoControllerSpec extends SpecBase {
 
   private val validAnswer: Boolean = true
 
-  private val baseAnswers: UserAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+  private val baseAnswers: UserAnswers = emptyUserAnswers
+    .set(SettlorAliveYesNoPage(index), true).success.value
+    .set(SettlorIndividualNamePage(index), name).success.value
 
   "UkCountryOfResidencyYesNo Controller" must {
 
     "return OK and the correct view for a GET" in {
 
-      val userAnswers = baseAnswers
+      val formContentInPastTense: Form[Boolean] = formProvider.withPrefix("settlorIndividualUkCountryOfResidencyYesNoPastTense")
+
+      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -59,7 +63,7 @@ class UkCountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, index, fakeDraftId, name)(request, messages).toString
+        view(formContentInPastTense, index, fakeDraftId, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
@@ -80,7 +84,7 @@ class UkCountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(validAnswer), index, fakeDraftId, name)(request, messages).toString
+        view(form.fill(validAnswer), index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
@@ -121,7 +125,7 @@ class UkCountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, index, fakeDraftId, name)(request, messages).toString
+        view(boundForm, index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/views/living_settlor/individual/SettlorIndividualAddressInternationalViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualAddressInternationalViewSpec.scala
@@ -28,33 +28,38 @@ import views.html.living_settlor.individual.SettlorIndividualAddressInternationa
 
 class SettlorIndividualAddressInternationalViewSpec extends InternationalAddressViewBehaviours {
 
-  val messageKeyPrefix = "settlorIndividualAddressInternational"
-  val index = 0
-  val name = FullName("First", None, "Last")
-
   override val form = new InternationalAddressFormProvider()()
+  private val index = 0
+  private val name = FullName("First", None, "Last")
 
-  "SettlorIndividualAddressInternationalView" must {
+  Seq(
+    ("settlorIndividualAddressInternational", true),
+    ("settlorIndividualAddressInternationalPastTense", false)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration) =>
 
-    val view = viewFor[SettlorIndividualAddressInternationalView](Some(emptyUserAnswers))
+      s"SettlorIndividualAddressInternationalView where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    val countryOptions: Seq[InputOption] = app.injector.instanceOf[CountryOptionsNonUK].options
+        val view = viewFor[SettlorIndividualAddressInternationalView](Some(emptyUserAnswers))
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, countryOptions, index, fakeDraftId, name)(fakeRequest, messages)
+        val countryOptions: Seq[InputOption] = app.injector.instanceOf[CountryOptionsNonUK].options
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, countryOptions, index, fakeDraftId, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like dynamicTitlePage(applyView(form), messageKey, name.toString)
 
-    behave like internationalAddress(
-      applyView,
-      Some("taskList.settlors.label"),
-      Some(messageKeyPrefix),
-      routes.SettlorIndividualAddressInternationalController.onSubmit(index, fakeDraftId).url,
-      name.toString
-    )
+        behave like pageWithBackLink(applyView(form))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like internationalAddress(
+          applyView,
+          Some("taskList.settlors.label"),
+          Some(messageKey),
+          routes.SettlorIndividualAddressInternationalController.onSubmit(index, fakeDraftId).url,
+          name.toString
+        )
+
+        behave like pageWithASubmitButton(applyView(form))
+      }
   }
 }

--- a/test/views/living_settlor/individual/SettlorIndividualAddressUKViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualAddressUKViewSpec.scala
@@ -25,30 +25,35 @@ import views.html.living_settlor.individual.SettlorIndividualAddressUKView
 
 class SettlorIndividualAddressUKViewSpec extends UkAddressViewBehaviours {
 
-  val messageKeyPrefix = "settlorIndividualAddressUK"
-  val index = 0
-  val name: FullName = FullName("First", Some("middle"), "Last")
-
   override val form = new UKAddressFormProvider()()
+  private val index = 0
+  private val name: FullName = FullName("First", Some("middle"), "Last")
 
-  "SettlorIndividualAddressUKView" must {
+  Seq(
+    ("settlorIndividualAddressUK", true),
+    ("settlorIndividualAddressUKPastTense", false)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration) =>
 
-    val view = viewFor[SettlorIndividualAddressUKView](Some(emptyUserAnswers))
+      s"SettlorIndividualAddressUKView where settlorAliveAtRegistration = $settlorAliveAtRegistration)" must {
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, fakeDraftId, index, name)(fakeRequest, messages)
+        val view = viewFor[SettlorIndividualAddressUKView](Some(emptyUserAnswers))
+
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, fakeDraftId, index, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(form), messageKey, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(form))
 
-    behave like ukAddressPage(
-      applyView,
-      Some(messageKeyPrefix),
-      name.toString
-    )
+        behave like ukAddressPage(
+          applyView,
+          Some(messageKey),
+          name.toString
+        )
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(form))
+      }
   }
 }

--- a/test/views/living_settlor/individual/SettlorIndividualAddressUKYesNoViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualAddressUKYesNoViewSpec.scala
@@ -25,24 +25,31 @@ import views.html.living_settlor.individual.SettlorIndividualAddressUKYesNoView
 
 class SettlorIndividualAddressUKYesNoViewSpec extends YesNoViewBehaviours {
 
-  val messageKeyPrefix = "settlorIndividualAddressUKYesNo"
-  val index = 0
-  val name = FullName("First", Some("Middle"), "Last")
-  val form = new YesNoFormProvider().withPrefix(messageKeyPrefix)
+  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualAddressUKYesNo")
+  private val formContentInPastTense: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualAddressUKYesNoPastTense")
+  private val index = 0
+  private val name = FullName("First", Some("Middle"), "Last")
 
-  "SettlorIndividualAddressUKYesNo view" must {
+  Seq(
+    ("settlorIndividualAddressUKYesNo", true, form),
+    ("settlorIndividualAddressUKYesNoPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-    val view = viewFor[SettlorIndividualAddressUKYesNoView](Some(emptyUserAnswers))
+      s"SettlorIndividualAddressUKYesNo view where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, fakeDraftId, index, name)(fakeRequest, messages)
+        val view = viewFor[SettlorIndividualAddressUKYesNoView](Some(emptyUserAnswers))
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, fakeDraftId, index, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like yesNoPage(form, applyView, messageKeyPrefix, None, Seq(name.toString))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like yesNoPage(formToUse, applyView, messageKey, None, Seq(name.toString))
+
+        behave like pageWithASubmitButton(applyView(formToUse))
+      }
   }
 }

--- a/test/views/living_settlor/individual/SettlorIndividualAddressYesNoViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualAddressYesNoViewSpec.scala
@@ -25,25 +25,31 @@ import views.html.living_settlor.individual.SettlorIndividualAddressYesNoView
 
 class SettlorIndividualAddressYesNoViewSpec extends YesNoViewBehaviours {
 
-  val messageKeyPrefix = "settlorIndividualAddressYesNo"
-  val index = 0
-  val name = FullName("First", Some("Middle"), "Last")
+  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualAddressYesNo")
+  private val formContentInPastTense: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualAddressYesNoPastTense")
+  private val index = 0
+  private val name = FullName("First", Some("Middle"), "Last")
 
-  val form = new YesNoFormProvider().withPrefix(messageKeyPrefix)
+  Seq(
+    ("settlorIndividualAddressYesNo", true, form),
+    ("settlorIndividualAddressYesNoPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-  "SettlorIndividualAddressYesNo view" must {
+      s"SettlorIndividualAddressYesNo view where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    val view = viewFor[SettlorIndividualAddressYesNoView](Some(emptyUserAnswers))
+        val view = viewFor[SettlorIndividualAddressYesNoView](Some(emptyUserAnswers))
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, fakeDraftId, index, name)(fakeRequest, messages)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, fakeDraftId, index, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like yesNoPage(form, applyView, messageKeyPrefix, None, Seq(name.toString))
+        behave like yesNoPage(formToUse, applyView, messageKey, None, Seq(name.toString))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(formToUse))
+      }
   }
 }

--- a/test/views/living_settlor/individual/mld5/CountryOfResidencyViewSpec.scala
+++ b/test/views/living_settlor/individual/mld5/CountryOfResidencyViewSpec.scala
@@ -25,25 +25,31 @@ import views.html.living_settlor.individual.mld5.CountryOfResidencyView
 
 class CountryOfResidencyViewSpec extends SelectCountryViewBehaviours {
 
-  private val messageKeyPrefix: String = "settlorIndividualCountryOfResidency"
+  override val form: Form[String] = new CountryFormProvider().withPrefix("settlorIndividualCountryOfResidency")
   private val index: Int = 0
   private val name: FullName = FullName("First", None, "Last")
+  private val formContentInPastTense: Form[String] = new CountryFormProvider().withPrefix("settlorIndividualCountryOfResidencyPastTense")
 
-  override val form: Form[String] = new CountryFormProvider().withPrefix(messageKeyPrefix)
+  Seq(
+    ("settlorIndividualCountryOfResidency", true, form),
+    ("settlorIndividualCountryOfResidencyPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-  "CountryOfResidency View" must {
+      s"CountryOfResidency View where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    val view = viewFor[CountryOfResidencyView](Some(emptyUserAnswers))
+        val view = viewFor[CountryOfResidencyView](Some(emptyUserAnswers))
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, index, fakeDraftId, countryOptions, name)(fakeRequest, messages)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like selectCountryPage(form, applyView, messageKeyPrefix, name.toString)
+        behave like selectCountryPage(formToUse, applyView, messageKey, name.toString)
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(formToUse))
+      }
   }
 }

--- a/test/views/living_settlor/individual/mld5/CountryOfResidencyYesNoViewSpec.scala
+++ b/test/views/living_settlor/individual/mld5/CountryOfResidencyYesNoViewSpec.scala
@@ -25,27 +25,34 @@ import views.html.living_settlor.individual.mld5.CountryOfResidencyYesNoView
 
 class CountryOfResidencyYesNoViewSpec extends YesNoViewBehaviours {
 
-  private val messageKeyPrefix: String = "settlorIndividualCountryOfResidencyYesNo"
   private val index: Int = 0
   private val name: FullName = FullName("First", None, "Last")
 
-  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix(messageKeyPrefix)
+  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualCountryOfResidencyYesNo")
+  private val formContentInPastTense: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualCountryOfResidencyYesNoPastTense")
 
-  "CountryOfResidencyYesNo View" must {
+  Seq(
+    ("settlorIndividualCountryOfResidencyYesNo", true, form),
+    ("settlorIndividualCountryOfResidencyYesNoPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-    val view = viewFor[CountryOfResidencyYesNoView](Some(emptyUserAnswers))
+      s"CountryOfResidencyYesNo View where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, index, fakeDraftId, name)(fakeRequest, messages)
+        val view = viewFor[CountryOfResidencyYesNoView](Some(emptyUserAnswers))
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, index, fakeDraftId, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like yesNoPage(form, applyView, messageKeyPrefix, None, Seq(name.toString))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like yesNoPage(formToUse, applyView, messageKey, Some(messageKey), Seq(name.toString))
 
-    behave like pageWithHint(applyView(form), s"$messageKeyPrefix.hint")
+        behave like pageWithASubmitButton(applyView(formToUse))
+
+        behave like pageWithHint(applyView(formToUse), expectedHintKey = s"$messageKey.hint")
+      }
   }
 }

--- a/test/views/living_settlor/individual/mld5/UkCountryOfResidencyYesNoViewSpec.scala
+++ b/test/views/living_settlor/individual/mld5/UkCountryOfResidencyYesNoViewSpec.scala
@@ -25,25 +25,31 @@ import views.html.living_settlor.individual.mld5.UkCountryOfResidencyYesNoView
 
 class UkCountryOfResidencyYesNoViewSpec extends YesNoViewBehaviours {
 
-  private val messageKeyPrefix: String = "settlorIndividualUkCountryOfResidencyYesNo"
+  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualUkCountryOfResidencyYesNo")
+  private val formContentInPastTense: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualUkCountryOfResidencyYesNoPastTense")
   private val index: Int = 0
   private val name: FullName = FullName("First", None, "Last")
 
-  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix(messageKeyPrefix)
+  Seq(
+    ("settlorIndividualUkCountryOfResidencyYesNo", true, form),
+    ("settlorIndividualUkCountryOfResidencyYesNoPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-  "UkCountryOfResidencyYesNo View" must {
+      s"UkCountryOfResidencyYesNo View where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    val view = viewFor[UkCountryOfResidencyYesNoView](Some(emptyUserAnswers))
+        val view = viewFor[UkCountryOfResidencyYesNoView](Some(emptyUserAnswers))
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, index, fakeDraftId, name)(fakeRequest, messages)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, index, fakeDraftId, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like yesNoPage(form, applyView, messageKeyPrefix, None, Seq(name.toString))
+        behave like yesNoPage(formToUse, applyView, messageKey, None, Seq(name.toString))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(formToUse))
+      }
   }
 }


### PR DESCRIPTION
Updated the logic for the country of residence and address questions:
- Where 'Is the settlor alive at the time of registration?' is true the content should be in present tense
- Where 'Is the settlor alive at the time of registration?' is false the content should be in the past tense

Note: The Welsh translations will be added after the PR is merged into the feature branch.