### PR TITLE
CR-PR013089: updated the living settlor journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,46 @@
 
 This service is responsible for collecting details about the settlor of the trust when registering a trust.
 
+## Running the micro-service
 To run locally using the micro-service provided by the service manager:
 
-***sm2 --start TRUSTS_ALL -r***
+```
+sm2 --start TRUSTS_ALL -r
+```
 
-or
+Or
 
-***sm2 --start REGISTER_TRUST_ALL -r***
+```
+sm2 --start REGISTER_TRUST_ALL -r
+```
+
 
 If you want to run your local copy, then stop the frontend ran by the service manager and run your local code by using the following (port number is 8843 but is defaulted to that in build.sbt):
 
-***sbt run***
+```sbt run```
+
+## Testing the service
+
+This service uses [sbt-scoverage](https://github.com/scoverage/sbt-scoverage) to
+provide test coverage reports.
+
+Use the following commands to run the tests with coverage and generate a report.
+
+Run this script before raising a PR to ensure your code changes pass the Jenkins pipeline. This runs all the unit tests with scalastyle and checks for dependency updates:
+```
+./run_all_tests.sh
+```
+
+
+## Making content changes
+
+### Messages in the past tense
+
+When adding content in the past tense for the check answer pages, include "PastTense" in the message key. This is so the content can be displayed in the correct tense on the registration draft page ([trusts-frontend](https://github.com/hmrc/trusts-frontend)). You will need to add the new message keys on [trusts-frontend](https://github.com/hmrc/trusts-frontend) as well. 
+
+Example:
+
+For the key```settlorIndividualName.checkYourAnswersLabel``` the past tense would be ```settlorIndividualNamePastTense.checkYourAnswersLabel``` 
 
 ### License
 

--- a/app/controllers/SettlorInfoController.scala
+++ b/app/controllers/SettlorInfoController.scala
@@ -39,7 +39,7 @@ class SettlorInfoController @Inject()(
   }
 
   def onSubmit(draftId: String): Action[AnyContent] = actions.authWithData(draftId) {
-      Redirect(controllers.trust_type.routes.SetUpAfterSettlorDiedController.onPageLoad(draftId))
+      Redirect(controllers.trust_type.routes.SetUpByLivingSettlorController.onPageLoad(draftId))
   }
 
 }

--- a/app/controllers/living_settlor/individual/SettlorIndividualAddressInternationalController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualAddressInternationalController.scala
@@ -21,6 +21,7 @@ import controllers.actions._
 import controllers.actions.living_settlor.individual.NameRequiredActionProvider
 import forms.InternationalAddressFormProvider
 import models.pages.InternationalAddress
+import models.requests.SettlorIndividualNameRequest
 import navigation.Navigator
 import pages.living_settlor.individual.{SettlorAddressInternationalPage, SettlorIndividualNamePage}
 import play.api.Logging
@@ -53,7 +54,7 @@ class SettlorIndividualAddressInternationalController @Inject()(
   private val form: Form[InternationalAddress] = formProvider()
 
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = (actions.authWithData(draftId) andThen requireName(index, draftId)) {
-    implicit request =>
+    implicit request: SettlorIndividualNameRequest[AnyContent] =>
 
       val name = request.userAnswers.get(SettlorIndividualNamePage(index)).get
 

--- a/app/controllers/living_settlor/individual/SettlorIndividualAddressInternationalController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualAddressInternationalController.scala
@@ -62,7 +62,7 @@ class SettlorIndividualAddressInternationalController @Inject()(
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, countryOptions.options, index, draftId, name))
+      Ok(view(preparedForm, countryOptions.options, index, draftId, name, request.settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = (actions.authWithData(draftId) andThen requireName(index, draftId)).async {
@@ -72,17 +72,16 @@ class SettlorIndividualAddressInternationalController @Inject()(
 
       form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, countryOptions.options, index, draftId, name))),
+          Future.successful(BadRequest(view(formWithErrors, countryOptions.options, index, draftId, name, request.settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(SettlorAddressInternationalPage(index), value) match {
             case Success(updatedAnswers) =>
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(SettlorAddressInternationalPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[SettlorIndividualAddressInternationalController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
         }
       )

--- a/app/controllers/living_settlor/individual/SettlorIndividualAddressUKController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualAddressUKController.scala
@@ -60,7 +60,7 @@ class SettlorIndividualAddressUKController @Inject()(
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, draftId, index, name))
+      Ok(view(preparedForm, draftId, index, name, request.settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = (actions.authWithData(draftId) andThen requireName(index, draftId)).async {
@@ -70,17 +70,16 @@ class SettlorIndividualAddressUKController @Inject()(
 
       form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, draftId, index, name))),
+          Future.successful(BadRequest(view(formWithErrors, draftId, index, name, request.settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(SettlorAddressUKPage(index), value) match {
             case Success(updatedAnswers) =>
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(SettlorAddressUKPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[SettlorIndividualAddressUKController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
         }
       )

--- a/app/controllers/living_settlor/individual/SettlorIndividualAddressYesNoController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualAddressYesNoController.scala
@@ -47,39 +47,40 @@ class SettlorIndividualAddressYesNoController @Inject()(
                                                          technicalErrorView: TechnicalErrorView
                                                        )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging{
 
-  private val form: Form[Boolean] = yesNoFormProvider.withPrefix("settlorIndividualAddressYesNo")
+  private def form(messageKey: String): Form[Boolean] = yesNoFormProvider.withPrefix(messageKey)
 
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = (actions.authWithData(draftId) andThen requireName(index, draftId)) {
     implicit request =>
 
       val name = request.userAnswers.get(SettlorIndividualNamePage(index)).get
+      val messageKeyPrefix = if(request.settlorAliveAtRegistration(index)) "settlorIndividualAddressYesNo" else "settlorIndividualAddressYesNoPastTense"
 
       val preparedForm = request.userAnswers.get(SettlorAddressYesNoPage(index)) match {
-        case None => form
-        case Some(value) => form.fill(value)
+        case None => form(messageKeyPrefix)
+        case Some(value) => form(messageKeyPrefix).fill(value)
       }
 
-      Ok(view(preparedForm, draftId, index, name))
+      Ok(view(preparedForm, draftId, index, name, request.settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = (actions.authWithData(draftId) andThen requireName(index, draftId)).async {
     implicit request =>
 
       val name = request.userAnswers.get(SettlorIndividualNamePage(index)).get
+      val messageKeyPrefix = if(request.settlorAliveAtRegistration(index)) "settlorIndividualAddressYesNo" else "settlorIndividualAddressYesNoPastTense"
 
-      form.bindFromRequest().fold(
+      form(messageKeyPrefix).bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, draftId, index, name))),
+          Future.successful(BadRequest(view(formWithErrors, draftId, index, name, request.settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(SettlorAddressYesNoPage(index), value) match {
             case Success(updatedAnswers) =>
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(SettlorAddressYesNoPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[SettlorIndividualAddressYesNoController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
         }
       )

--- a/app/controllers/living_settlor/individual/SettlorIndividualAnswerController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualAnswerController.scala
@@ -57,7 +57,8 @@ class SettlorIndividualAnswerController @Inject()(
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = actions(index, draftId) {
     implicit request =>
 
-      val section = livingSettlorPrintHelper.checkDetailsSection(request.userAnswers, request.name.toString, draftId, index)
+      val messageKeyPrefix =  if(request.settlorAliveAtRegistration(index)) None else Some("PastTense")
+      val section = livingSettlorPrintHelper.checkDetailsSection(request.userAnswers, request.name.toString, draftId, index, prefix = messageKeyPrefix)
 
       Ok(view(routes.SettlorIndividualAnswerController.onSubmit(index, draftId), Seq(section)))
   }
@@ -71,10 +72,9 @@ class SettlorIndividualAnswerController @Inject()(
             draftRegistrationService.removeDeceasedSettlorMappedPiece(draftId)
             Redirect(navigator.nextPage(SettlorIndividualAnswerPage, draftId)(updatedAnswers))
           }
-        case Failure(_) => {
+        case Failure(_) =>
           logger.error("[SettlorIndividualAnswerController][onSubmit] Error while storing user answers")
           Future.successful(InternalServerError(technicalErrorView()))
-        }
       }
   }
 

--- a/app/controllers/living_settlor/individual/SettlorIndividualDateOfBirthController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualDateOfBirthController.scala
@@ -21,7 +21,7 @@ import controllers.actions._
 import controllers.actions.living_settlor.individual.NameRequiredActionProvider
 import forms.DateOfBirthFormProvider
 import navigation.Navigator
-import pages.living_settlor.individual.{SettlorIndividualDateOfBirthPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualDateOfBirthPage, SettlorIndividualNamePage}
 import play.api.Logging
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -53,6 +53,13 @@ class SettlorIndividualDateOfBirthController @Inject()(
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = (actions.authWithData(draftId) andThen requireName(index, draftId)) {
     implicit request =>
 
+      val setUpAfterSettlorDied: Boolean = request
+        .userAnswers
+        .get(SettlorAliveYesNoPage(index)) match {
+        case Some(value) => value
+        case None => false
+      }
+
       val name = request.userAnswers.get(SettlorIndividualNamePage(index)).get
 
       val preparedForm = request.userAnswers.get(SettlorIndividualDateOfBirthPage(index)) match {
@@ -60,17 +67,24 @@ class SettlorIndividualDateOfBirthController @Inject()(
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, draftId, index, name))
+      Ok(view(preparedForm, draftId, index, name, setUpAfterSettlorDied))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = (actions.authWithData(draftId) andThen requireName(index, draftId)).async {
     implicit request =>
 
+      val setUpAfterSettlorDied: Boolean = request
+        .userAnswers
+        .get(SettlorAliveYesNoPage(index)) match {
+        case Some(value) => value
+        case None => false
+      }
+
       val name = request.userAnswers.get(SettlorIndividualNamePage(index)).get
 
       form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, draftId, index, name))),
+          Future.successful(BadRequest(view(formWithErrors, draftId, index, name, setUpAfterSettlorDied))),
         value => {
           request.userAnswers.set(SettlorIndividualDateOfBirthPage(index), value) match {
             case Success(updatedAnswers) =>

--- a/app/controllers/living_settlor/individual/SettlorIndividualIDCardController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualIDCardController.scala
@@ -62,7 +62,7 @@ class SettlorIndividualIDCardController @Inject()(
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, countryOptions.options, draftId, index, name))
+      Ok(view(preparedForm, countryOptions.options, draftId, index, name, request.settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = (actions.authWithData(draftId) andThen requireName(index, draftId)).async {
@@ -72,7 +72,7 @@ class SettlorIndividualIDCardController @Inject()(
 
       form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, countryOptions.options, draftId, index, name))),
+          Future.successful(BadRequest(view(formWithErrors, countryOptions.options, draftId, index, name, request.settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(SettlorIndividualIDCardPage(index), value) match {
             case Success(updatedAnswers) =>

--- a/app/controllers/living_settlor/individual/SettlorIndividualNameController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualNameController.scala
@@ -20,8 +20,9 @@ import config.annotations.IndividualSettlor
 import controllers.actions.Actions
 import forms.living_settlor.SettlorIndividualNameFormProvider
 import models.pages.FullName
+import models.requests.RegistrationDataRequest
 import navigation.Navigator
-import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.SettlorIndividualNamePage
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -48,37 +49,23 @@ class SettlorIndividualNameController @Inject()(
   private val form: Form[FullName] = formProvider()
 
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = actions.authWithData(draftId) {
-    implicit request => {
-
-      val setUpAfterSettlorDied: Boolean = request
-        .userAnswers
-        .get(SettlorAliveYesNoPage(index)) match {
-          case Some(value) => value
-          case None => false
-        }
+    implicit request: RegistrationDataRequest[AnyContent] => {
 
       val preparedForm = request.userAnswers.get(SettlorIndividualNamePage(index)) match {
         case None => form
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, draftId, index, setUpAfterSettlorDied))
+      Ok(view(preparedForm, draftId, index, request.settlorAliveAtRegistration(index)))
     }
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = actions.authWithData(draftId).async {
-    implicit request =>
-
-      val setUpAfterSettlorDied: Boolean = request
-        .userAnswers
-        .get(SettlorAliveYesNoPage(index)) match {
-          case Some(value) => value
-          case None => false
-        }
+    implicit request: RegistrationDataRequest[AnyContent] =>
 
       form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, draftId, index, setUpAfterSettlorDied))),
+          Future.successful(BadRequest(view(formWithErrors, draftId, index, request.settlorAliveAtRegistration(index)))),
 
         value => {
           request.userAnswers.set(SettlorIndividualNamePage(index), value) match {

--- a/app/controllers/living_settlor/individual/SettlorIndividualPassportController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualPassportController.scala
@@ -62,7 +62,7 @@ class SettlorIndividualPassportController @Inject()(
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, countryOptions.options, draftId, index, name))
+      Ok(view(preparedForm, countryOptions.options, draftId, index, name, request.settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = (actions.authWithData(draftId) andThen requireName(index, draftId)).async {
@@ -72,7 +72,7 @@ class SettlorIndividualPassportController @Inject()(
 
       form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, countryOptions.options, draftId, index, name))),
+          Future.successful(BadRequest(view(formWithErrors, countryOptions.options, draftId, index, name, request.settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(SettlorIndividualPassportPage(index), value) match {
             case Success(updatedAnswers) =>

--- a/app/controllers/living_settlor/individual/mld5/CountryOfNationalityController.scala
+++ b/app/controllers/living_settlor/individual/mld5/CountryOfNationalityController.scala
@@ -50,7 +50,7 @@ class CountryOfNationalityController @Inject()(
                                                 technicalErrorView: TechnicalErrorView
                                               )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging {
 
-  private val form: Form[String] = countryFormProvider.withPrefix("settlorIndividualCountryOfNationality")
+  private def form(messageKey: String): Form[String] = countryFormProvider.withPrefix(messageKey)
 
   private def action(index: Int, draftId: String): ActionBuilder[SettlorIndividualNameRequest, AnyContent] = {
     actions.authWithData(draftId) andThen requireName(index, draftId)
@@ -59,30 +59,35 @@ class CountryOfNationalityController @Inject()(
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = action(index, draftId) {
     implicit request =>
 
+      val messageKeyPrefix =
+        if(request.settlorAliveAtRegistration(index)) "settlorIndividualCountryOfNationality" else "settlorIndividualCountryOfNationalityPastTense"
+
       val preparedForm = request.userAnswers.get(CountryOfNationalityPage(index)) match {
-        case None => form
-        case Some(value) => form.fill(value)
+        case None => form(messageKeyPrefix)
+        case Some(value) => form(messageKeyPrefix).fill(value)
       }
 
-      Ok(view(preparedForm, index, draftId, countryOptions.options(), request.name))
+      Ok(view(preparedForm, index, draftId, countryOptions.options(), request.name, request.settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = action(index, draftId).async {
     implicit request =>
 
-      form.bindFromRequest().fold(
+      val messageKeyPrefix =
+        if(request.settlorAliveAtRegistration(index)) "settlorIndividualCountryOfNationality" else "settlorIndividualCountryOfNationalityPastTense"
+
+      form(messageKeyPrefix).bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, index, draftId, countryOptions.options(), request.name))),
+          Future.successful(BadRequest(view(formWithErrors, index, draftId, countryOptions.options(), request.name, request.settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(CountryOfNationalityPage(index), value) match {
             case Success(updatedAnswers) =>
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(CountryOfNationalityPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[CountryOfNationalityController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
         }
       )

--- a/app/controllers/living_settlor/individual/mld5/CountryOfResidencyController.scala
+++ b/app/controllers/living_settlor/individual/mld5/CountryOfResidencyController.scala
@@ -64,7 +64,7 @@ class CountryOfResidencyController @Inject()(
         case Some(value) => form.fill(value)
       }
 
-      Ok(view(preparedForm, index, draftId, countryOptions.options(), request.name))
+      Ok(view(preparedForm, index, draftId, countryOptions.options(), request.name, request.settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = action(index, draftId).async {
@@ -72,17 +72,16 @@ class CountryOfResidencyController @Inject()(
 
       form.bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, index, draftId, countryOptions.options(), request.name))),
+          Future.successful(BadRequest(view(formWithErrors, index, draftId, countryOptions.options(), request.name, request.settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(CountryOfResidencyPage(index), value) match {
             case Success(updatedAnswers) =>
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(CountryOfResidencyPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[CountryOfResidencyController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
         }
       )

--- a/app/controllers/living_settlor/individual/mld5/MentalCapacityYesNoController.scala
+++ b/app/controllers/living_settlor/individual/mld5/MentalCapacityYesNoController.scala
@@ -78,10 +78,9 @@ class MentalCapacityYesNoController @Inject()(
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(MentalCapacityYesNoPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[MentalCapacityYesNoController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
       )
   }

--- a/app/controllers/living_settlor/individual/mld5/UkCountryOfNationalityYesNoController.scala
+++ b/app/controllers/living_settlor/individual/mld5/UkCountryOfNationalityYesNoController.scala
@@ -48,7 +48,7 @@ class UkCountryOfNationalityYesNoController @Inject()(
                                                        technicalErrorView: TechnicalErrorView
                                                      )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging {
 
-  private val form: Form[Boolean] = yesNoFormProvider.withPrefix("settlorIndividualUkCountryOfNationalityYesNo")
+  private def form(messageKey: String): Form[Boolean] = yesNoFormProvider.withPrefix(messageKey)
 
   private def action(index: Int, draftId: String): ActionBuilder[SettlorIndividualNameRequest, AnyContent] = {
     actions.authWithData(draftId) andThen requireName(index, draftId)
@@ -57,20 +57,26 @@ class UkCountryOfNationalityYesNoController @Inject()(
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = action(index, draftId) {
     implicit request =>
 
+      val messageKeyPrefix =
+        if(request.settlorAliveAtRegistration(index)) "settlorIndividualUkCountryOfNationalityYesNo" else "settlorIndividualUkCountryOfNationalityYesNoPastTense"
+
       val preparedForm = request.userAnswers.get(UkCountryOfNationalityYesNoPage(index)) match {
-        case None => form
-        case Some(value) => form.fill(value)
+        case None => form(messageKeyPrefix)
+        case Some(value) => form(messageKeyPrefix).fill(value)
       }
 
-      Ok(view(preparedForm, index, draftId, request.name))
+      Ok(view(preparedForm, index, draftId, request.name, request.settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = action(index, draftId).async {
     implicit request =>
 
-      form.bindFromRequest().fold(
+      val messageKeyPrefix =
+        if(request.settlorAliveAtRegistration(index)) "settlorIndividualUkCountryOfNationalityYesNo" else "settlorIndividualUkCountryOfNationalityYesNoPastTense"
+
+      form(messageKeyPrefix).bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, index, draftId, request.name))),
+          Future.successful(BadRequest(view(formWithErrors, index, draftId, request.name, request.settlorAliveAtRegistration(index)))),
 
         value => {
           request.userAnswers.set(UkCountryOfNationalityYesNoPage(index), value) match {
@@ -78,10 +84,9 @@ class UkCountryOfNationalityYesNoController @Inject()(
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(UkCountryOfNationalityYesNoPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[UkCountryOfNationalityYesNoController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
         }
       )

--- a/app/controllers/living_settlor/individual/mld5/UkCountryOfResidencyYesNoController.scala
+++ b/app/controllers/living_settlor/individual/mld5/UkCountryOfResidencyYesNoController.scala
@@ -48,7 +48,7 @@ class UkCountryOfResidencyYesNoController @Inject()(
                                                      technicalErrorView: TechnicalErrorView
                                                    )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging{
 
-  private val form: Form[Boolean] = yesNoFormProvider.withPrefix("settlorIndividualUkCountryOfResidencyYesNo")
+  private def form(messageKey: String): Form[Boolean] = yesNoFormProvider.withPrefix(messageKey)
 
   private def action(index: Int, draftId: String): ActionBuilder[SettlorIndividualNameRequest, AnyContent] = {
     actions.authWithData(draftId) andThen requireName(index, draftId)
@@ -57,30 +57,35 @@ class UkCountryOfResidencyYesNoController @Inject()(
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = action(index, draftId) {
     implicit request =>
 
+      val messageKeyPrefix =
+        if(request.settlorAliveAtRegistration(index)) "settlorIndividualUkCountryOfResidencyYesNo"else "settlorIndividualUkCountryOfResidencyYesNoPastTense"
+
       val preparedForm = request.userAnswers.get(UkCountryOfResidencyYesNoPage(index)) match {
-        case None => form
-        case Some(value) => form.fill(value)
+        case None => form(messageKeyPrefix)
+        case Some(value) => form(messageKeyPrefix).fill(value)
       }
 
-      Ok(view(preparedForm, index, draftId, request.name))
+      Ok(view(preparedForm, index, draftId, request.name, request.settlorAliveAtRegistration(index)))
   }
 
   def onSubmit(index: Int, draftId: String): Action[AnyContent] = action(index, draftId).async {
     implicit request =>
 
-      form.bindFromRequest().fold(
+      val messageKeyPrefix =
+        if(request.settlorAliveAtRegistration(index)) "settlorIndividualUkCountryOfResidencyYesNo"else "settlorIndividualUkCountryOfResidencyYesNoPastTense"
+
+      form(messageKeyPrefix).bindFromRequest().fold(
         (formWithErrors: Form[_]) =>
-          Future.successful(BadRequest(view(formWithErrors, index, draftId, request.name))),
+          Future.successful(BadRequest(view(formWithErrors, index, draftId, request.name, request.settlorAliveAtRegistration(index)))),
         value => {
           request.userAnswers.set(UkCountryOfResidencyYesNoPage(index), value) match {
             case Success(updatedAnswers) =>
               registrationsRepository.set(updatedAnswers).map { _ =>
                 Redirect(navigator.nextPage(UkCountryOfResidencyYesNoPage(index), draftId)(updatedAnswers))
               }
-            case Failure(_) => {
+            case Failure(_) =>
               logger.error("[UkCountryOfResidencyYesNoController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
-            }
           }
         }
       )

--- a/app/controllers/trust_type/HoldoverReliefYesNoController.scala
+++ b/app/controllers/trust_type/HoldoverReliefYesNoController.scala
@@ -20,7 +20,7 @@ import config.annotations.TrustType
 import controllers.actions._
 import forms.YesNoFormProvider
 import navigation.Navigator
-import pages.trust_type.{HoldoverReliefYesNoPage, SetUpAfterSettlorDiedYesNoPage}
+import pages.trust_type.{HoldoverReliefYesNoPage, SetUpByLivingSettlorYesNoPage}
 import play.api.Logging
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -50,7 +50,7 @@ class HoldoverReliefYesNoController @Inject()(
 
   private def actions(draftId: String) =
     standardActions.authWithData(draftId) andThen
-      requiredAnswer(RequiredAnswer(SetUpAfterSettlorDiedYesNoPage, routes.SetUpAfterSettlorDiedController.onPageLoad(draftId)))
+      requiredAnswer(RequiredAnswer(SetUpByLivingSettlorYesNoPage, routes.SetUpByLivingSettlorController.onPageLoad(draftId)))
 
   def onPageLoad(draftId: String): Action[AnyContent] = actions(draftId) {
     implicit request =>

--- a/app/controllers/trust_type/KindOfTrustController.scala
+++ b/app/controllers/trust_type/KindOfTrustController.scala
@@ -23,7 +23,7 @@ import models.Enumerable
 import models.pages.KindOfTrust
 import models.requests.RegistrationDataRequest
 import navigation.Navigator
-import pages.trust_type.{KindOfTrustPage, SetUpAfterSettlorDiedYesNoPage}
+import pages.trust_type.{KindOfTrustPage, SetUpByLivingSettlorYesNoPage}
 import play.api.Logging
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -51,7 +51,7 @@ class KindOfTrustController @Inject()(
 
   private def actions(draftId: String): ActionBuilder[RegistrationDataRequest, AnyContent] =
     standardActions.authWithData(draftId) andThen
-      requiredAnswer(RequiredAnswer(SetUpAfterSettlorDiedYesNoPage, routes.SetUpAfterSettlorDiedController.onPageLoad(draftId)))
+      requiredAnswer(RequiredAnswer(SetUpByLivingSettlorYesNoPage, routes.SetUpByLivingSettlorController.onPageLoad(draftId)))
 
   private val form: Form[KindOfTrust] = formProvider()
 

--- a/app/controllers/trust_type/SetUpByLivingSettlorController.scala
+++ b/app/controllers/trust_type/SetUpByLivingSettlorController.scala
@@ -20,7 +20,7 @@ import config.annotations.TrustType
 import controllers.actions.Actions
 import forms.YesNoFormProvider
 import navigation.Navigator
-import pages.trust_type.SetUpAfterSettlorDiedYesNoPage
+import pages.trust_type.SetUpByLivingSettlorYesNoPage
 import play.api.Logging
 import play.api.data.Form
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -28,29 +28,29 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.RegistrationsRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.errors.TechnicalErrorView
-import views.html.trust_type.SetUpAfterSettlorDiedView
+import views.html.trust_type.SetUpByLivingSettlorView
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
-class SetUpAfterSettlorDiedController @Inject()(
+class SetUpByLivingSettlorController @Inject()(
                                                  override val messagesApi: MessagesApi,
                                                  registrationsRepository: RegistrationsRepository,
                                                  @TrustType navigator: Navigator,
                                                  actions: Actions,
                                                  yesNoFormProvider: YesNoFormProvider,
                                                  val controllerComponents: MessagesControllerComponents,
-                                                 view: SetUpAfterSettlorDiedView,
+                                                 view: SetUpByLivingSettlorView,
                                                  technicalErrorView: TechnicalErrorView
                                                )(implicit ec: ExecutionContext) extends FrontendBaseController with I18nSupport with Logging {
 
-  private val form: Form[Boolean] = yesNoFormProvider.withPrefix("setUpAfterSettlorDiedYesNo")
+  private val form: Form[Boolean] = yesNoFormProvider.withPrefix("setUpByLivingSettlorYesNo")
 
   def onPageLoad(draftId: String): Action[AnyContent] = actions.authWithData(draftId) {
     implicit request =>
 
-      val preparedForm = request.userAnswers.get(SetUpAfterSettlorDiedYesNoPage) match {
+      val preparedForm: Form[Boolean] = request.userAnswers.get(SetUpByLivingSettlorYesNoPage) match {
         case None => form
         case Some(value) => form.fill(value)
       }
@@ -65,13 +65,13 @@ class SetUpAfterSettlorDiedController @Inject()(
         (formWithErrors: Form[_]) =>
           Future.successful(BadRequest(view(formWithErrors, draftId, request.userAnswers.isTaxable))),
         value => {
-          request.userAnswers.set(SetUpAfterSettlorDiedYesNoPage, value) match {
+          request.userAnswers.set(SetUpByLivingSettlorYesNoPage, value) match {
             case Success(updatedAnswers) =>
               registrationsRepository.set(updatedAnswers).map { _ =>
-                Redirect(navigator.nextPage(SetUpAfterSettlorDiedYesNoPage, draftId)(updatedAnswers))
+                Redirect(navigator.nextPage(SetUpByLivingSettlorYesNoPage, draftId)(updatedAnswers))
               }
             case Failure(_) => {
-              logger.error("[SetUpAfterSettlorDiedController][onSubmit] Error while storing user answers")
+              logger.error("[SetUpByLivingSettlorController][onSubmit] Error while storing user answers")
               Future.successful(InternalServerError(technicalErrorView()))
             }
           }

--- a/app/mapping/IndividualSettlorsMapper.scala
+++ b/app/mapping/IndividualSettlorsMapper.scala
@@ -18,22 +18,24 @@ package mapping
 
 import mapping.reads.IndividualSettlor
 import models.Settlor
-import models.YesNoDontKnow.{DontKnow, No, Yes}
+import models.YesNoDontKnow.{No, Yes}
 
 class IndividualSettlorsMapper extends Mapping[Settlor, IndividualSettlor] {
 
-  override def settlorType(settlor: IndividualSettlor): Settlor = Settlor(
-    name = settlor.name,
-    dateOfBirth = settlor.dateOfBirth,
-    identification = settlor.identification,
-    countryOfResidence = settlor.countryOfResidence,
-    nationality = settlor.nationality,
-    legallyIncapable = {
-      settlor.hasMentalCapacity.flatMap {
-        case Yes => Some(false)
-        case No => Some(true)
-        case DontKnow => None
+  override def settlorType(settlor: IndividualSettlor): Settlor =
+    Settlor(
+      aliveAtRegistration = settlor.aliveAtRegistration,
+      name = settlor.name,
+      dateOfBirth = settlor.dateOfBirth,
+      identification = settlor.identification,
+      countryOfResidence = settlor.countryOfResidence,
+      nationality = settlor.nationality,
+      legallyIncapable = {
+        (settlor.aliveAtRegistration, settlor.hasMentalCapacity) match {
+          case (true, Some(Yes)) => Some(false)
+          case (true, Some(No)) => Some(true)
+          case (_, _) => None
+        }
       }
-    }
-  )
+    )
 }

--- a/app/mapping/reads/IndividualSettlor.scala
+++ b/app/mapping/reads/IndividualSettlor.scala
@@ -24,7 +24,8 @@ import play.api.libs.json.{Reads, __}
 
 import java.time.LocalDate
 
-final case class IndividualSettlor(name: FullName,
+final case class IndividualSettlor(aliveAtRegistration: Boolean,
+                                   name: FullName,
                                    dateOfBirth: Option[LocalDate],
                                    nino: Option[String],
                                    address: Option[Address],
@@ -45,7 +46,8 @@ final case class IndividualSettlor(name: FullName,
 object IndividualSettlor extends SettlorReads {
 
   implicit lazy val reads: Reads[IndividualSettlor] = (
-    (__ \ "name").read[FullName] and
+    (__ \ "aliveAtRegistration").read[Boolean] and
+      (__ \ "name").read[FullName] and
       (__ \ "dateOfBirth").readNullable[LocalDate] and
       (__ \ "nino").readNullable[String] and
       readAddress() and
@@ -54,6 +56,6 @@ object IndividualSettlor extends SettlorReads {
       (__ \ "countryOfResidency").readNullable[String] and
       (__ \ "countryOfNationality").readNullable[String] and
       readMentalCapacity
-    )(IndividualSettlor.apply _)
+    ) (IndividualSettlor.apply _)
 
 }

--- a/app/models/TrustRegistrationModels.scala
+++ b/app/models/TrustRegistrationModels.scala
@@ -30,7 +30,8 @@ object Settlors {
   implicit val settlorsFormat: Format[Settlors] = Json.format[Settlors]
 }
 
-case class Settlor(name: FullName,
+case class Settlor(aliveAtRegistration: Boolean,
+                   name: FullName,
                    dateOfBirth: Option[LocalDate],
                    identification: Option[IdentificationType],
                    countryOfResidence: Option[String],

--- a/app/models/requests/RegistrationDataRequest.scala
+++ b/app/models/requests/RegistrationDataRequest.scala
@@ -17,6 +17,7 @@
 package models.requests
 
 import models.UserAnswers
+import pages.living_settlor.individual.SettlorAliveYesNoPage
 import play.api.mvc.{Request, WrappedRequest}
 import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolments}
 
@@ -34,4 +35,13 @@ case class RegistrationDataRequest[A](request: Request[A],
                                       affinityGroup: AffinityGroup,
                                       enrolments: Enrolments,
                                       agentARN: Option[String] = None)
-  extends WrappedRequest[A](request)
+  extends WrappedRequest[A](request){
+
+    def settlorAliveAtRegistration(index: Int): Boolean = {
+      userAnswers.get(SettlorAliveYesNoPage(index)) match {
+        case Some(value) => value
+        case None => false
+      }
+    }
+
+}

--- a/app/models/requests/SettlorIndividualNameRequest.scala
+++ b/app/models/requests/SettlorIndividualNameRequest.scala
@@ -18,8 +18,16 @@ package models.requests
 
 import models.UserAnswers
 import models.pages.FullName
+import pages.living_settlor.individual.SettlorAliveYesNoPage
 import play.api.mvc.WrappedRequest
 
 case class SettlorIndividualNameRequest[T](request: RegistrationDataRequest[T], name: FullName) extends WrappedRequest[T](request){
   val userAnswers:UserAnswers = request.userAnswers
+
+  def settlorAliveAtRegistration(index: Int): Boolean = {
+    userAnswers.get(SettlorAliveYesNoPage(index)) match {
+      case Some(value) => value
+      case None => false
+    }
+  }
 }

--- a/app/navigation/IndividualSettlorNavigator.scala
+++ b/app/navigation/IndividualSettlorNavigator.scala
@@ -40,6 +40,8 @@ class IndividualSettlorNavigator extends Navigator {
   }
 
   private def simpleNavigation(draftId: String): PartialFunction[Page, UserAnswers => Call] = {
+    case SettlorAliveYesNoPage(index) => _ =>
+      SettlorIndividualNameController.onPageLoad(index, draftId)
     case SettlorIndividualNamePage(index) => _ =>
       SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, draftId)
     case CountryOfNationalityPage(index) => ua =>
@@ -100,10 +102,10 @@ class IndividualSettlorNavigator extends Navigator {
       CountryOfNationalityYesNoController.onPageLoad(index, draftId)
     case SettlorIndividualNINOPage(index) => _ =>
         CountryOfResidencyYesNoController.onPageLoad(index, draftId)
-    case SettlorIndividualPassportPage(index) => _ =>
-      MentalCapacityYesNoController.onPageLoad(index, draftId)
-    case SettlorIndividualIDCardPage(index) => _ =>
-      MentalCapacityYesNoController.onPageLoad(index, draftId)
+    case SettlorIndividualPassportPage(index) => ua =>
+      showOrHideMentalCapacityQuestion(ua, index, draftId)
+    case SettlorIndividualIDCardPage(index) => ua =>
+      showOrHideMentalCapacityQuestion(ua, index, draftId)
   }
 
   private def mldDependentYesNoNavigation(draftId: String): PartialFunction[Page, UserAnswers => Call] = {
@@ -123,13 +125,13 @@ class IndividualSettlorNavigator extends Navigator {
       yesNoNav(
         fromPage = page,
         yesCall = SettlorIndividualAddressUKYesNoController.onPageLoad(index, draftId),
-        noCall = MentalCapacityYesNoController.onPageLoad(index, draftId)
+        noCall = showOrHideMentalCapacityQuestion(ua, index, draftId)
       )(ua)
     case page @ SettlorIndividualIDCardYesNoPage(index) => ua =>
       yesNoNav(
         fromPage = page,
         yesCall = SettlorIndividualIDCardController.onPageLoad(index, draftId),
-        noCall = MentalCapacityYesNoController.onPageLoad(index, draftId)
+        noCall = showOrHideMentalCapacityQuestion(ua, index, draftId)
       )(ua)
   }
 
@@ -143,7 +145,7 @@ class IndividualSettlorNavigator extends Navigator {
 
   private def navigateAwayFromCountryOfResidencyQuestions(ua: UserAnswers, index: Int, draftId: String): Call = {
     if (isNinoDefined(ua, index) || !ua.isTaxable) {
-      MentalCapacityYesNoController.onPageLoad(index, draftId)
+      showOrHideMentalCapacityQuestion(ua, index, draftId)
     } else {
       SettlorIndividualAddressYesNoController.onPageLoad(index, draftId)
     }
@@ -151,5 +153,13 @@ class IndividualSettlorNavigator extends Navigator {
 
   private def isNinoDefined(ua: UserAnswers, index: Int): Boolean = {
     ua.get(SettlorIndividualNINOPage(index)).isDefined
+  }
+
+  private def showOrHideMentalCapacityQuestion(ua: UserAnswers, index: Int, draftId: String): Call = {
+    if(ua.get(SettlorAliveYesNoPage(index)).contains(true)) {
+      MentalCapacityYesNoController.onPageLoad(index, draftId)
+    } else {
+      SettlorIndividualAnswerController.onPageLoad(index, draftId)
+    }
   }
 }

--- a/app/navigation/SettlorNavigator.scala
+++ b/app/navigation/SettlorNavigator.scala
@@ -21,7 +21,6 @@ import models.UserAnswers
 import models.pages.AddASettlor._
 import models.pages.IndividualOrBusiness
 import models.pages.IndividualOrBusiness.{Business, Individual}
-import models.pages.KindOfTrust._
 import pages.living_settlor._
 import pages.{AddASettlorPage, AddASettlorYesNoPage, _}
 import play.api.mvc.Call
@@ -41,7 +40,7 @@ class SettlorNavigator @Inject()(config: FrontendAppConfig) extends Navigator {
     case AddASettlorPage => addSettlorRoute(draftId)
     case AddASettlorYesNoPage => yesNoNav(
       fromPage = AddASettlorYesNoPage,
-      yesCall = controllers.trust_type.routes.SetUpAfterSettlorDiedController.onPageLoad(draftId),
+      yesCall = controllers.trust_type.routes.SetUpByLivingSettlorController.onPageLoad(draftId),
       noCall = settlorsCompletedRoute(draftId)
     )
     case SettlorIndividualOrBusinessPage(index) => settlorIndividualOrBusinessPage(index, draftId)
@@ -89,7 +88,7 @@ object SettlorNavigator {
   }
 
   private def routeToIndividualSettlorIndex(answers: UserAnswers, draftId: String, index: Option[Int]): Call = {
-    routeToIndex(answers, controllers.living_settlor.individual.routes.SettlorIndividualNameController.onPageLoad, draftId, index)
+    routeToIndex(answers, controllers.living_settlor.individual.routes.SettlorAliveYesNoController.onPageLoad, draftId, index)
   }
 
   private def routeToSettlorProtectorIndex(answers: UserAnswers, draftId: String, index: Option[Int]): Call = {

--- a/app/navigation/TrustTypeNavigator.scala
+++ b/app/navigation/TrustTypeNavigator.scala
@@ -35,14 +35,14 @@ class TrustTypeNavigator extends Navigator {
                         draftId: String): UserAnswers => Call = route(draftId)(page)
 
   override protected def route(draftId: String): PartialFunction[Page, UserAnswers => Call] = {
-    case SetUpAfterSettlorDiedYesNoPage => ua => yesNoNav(
-      fromPage = SetUpAfterSettlorDiedYesNoPage,
-      yesCall = SettlorsNameController.onPageLoad(draftId),
-      noCall = if (ua.isTaxable) {
+    case SetUpByLivingSettlorYesNoPage => ua => yesNoNav(
+      fromPage = SetUpByLivingSettlorYesNoPage,
+      yesCall = if (ua.isTaxable) {
         KindOfTrustController.onPageLoad(draftId)
       } else {
         redirectToLivingSettlorQuestions(draftId)
-      }
+      },
+      noCall = SettlorsNameController.onPageLoad(draftId)
     )(ua)
     case KindOfTrustPage => kindOfTrustPage(draftId)
     case EfrbsYesNoPage => yesNoNav(

--- a/app/pages/RegistrationProgress.scala
+++ b/app/pages/RegistrationProgress.scala
@@ -19,7 +19,7 @@ package pages
 import models.UserAnswers
 import models.pages.Status.{Completed, InProgress}
 import models.pages.{AddASettlor, Status}
-import pages.trust_type.{SetUpAfterSettlorDiedYesNoPage, SetUpInAdditionToWillTrustYesNoPage}
+import pages.trust_type.{SetUpByLivingSettlorYesNoPage, SetUpInAdditionToWillTrustYesNoPage}
 import sections.LivingSettlors
 import viewmodels.SettlorViewModel
 
@@ -33,13 +33,13 @@ class RegistrationProgress @Inject()() {
       userAnswers.get(DeceasedSettlorStatus).contains(Completed)
     )
 
-    val setupAfterDied = userAnswers.get(SetUpAfterSettlorDiedYesNoPage)
+    val setupByLivingSettlor = userAnswers.get(SetUpByLivingSettlorYesNoPage)
 
-    setupAfterDied flatMap { setupAfter =>
-      if (setupAfter) {
-        deceasedStatus
-      } else {
+    setupByLivingSettlor flatMap { setupByLivingSettlor =>
+      if (setupByLivingSettlor) {
         statusForNonWillTrust(userAnswers, deceasedStatus)
+      } else {
+        deceasedStatus
       }
     }
   }

--- a/app/pages/living_settlor/SettlorIndividualOrBusinessPage.scala
+++ b/app/pages/living_settlor/SettlorIndividualOrBusinessPage.scala
@@ -22,7 +22,7 @@ import models.pages.IndividualOrBusiness.{Business, Individual}
 import pages.QuestionPage
 import pages.LivingSettlorStatus
 import pages.living_settlor.business._
-import pages.living_settlor.individual.{SettlorAddressInternationalPage, SettlorAddressUKPage, SettlorAddressUKYesNoPage, SettlorAddressYesNoPage, SettlorIndividualDateOfBirthPage, SettlorIndividualDateOfBirthYesNoPage, SettlorIndividualIDCardPage, SettlorIndividualIDCardYesNoPage, SettlorIndividualNINOPage, SettlorIndividualNINOYesNoPage, SettlorIndividualNamePage, SettlorIndividualPassportPage, SettlorIndividualPassportYesNoPage}
+import pages.living_settlor.individual.{SettlorAddressInternationalPage, SettlorAddressUKPage, SettlorAddressUKYesNoPage, SettlorAddressYesNoPage, SettlorAliveYesNoPage, SettlorIndividualDateOfBirthPage, SettlorIndividualDateOfBirthYesNoPage, SettlorIndividualIDCardPage, SettlorIndividualIDCardYesNoPage, SettlorIndividualNINOPage, SettlorIndividualNINOYesNoPage, SettlorIndividualNamePage, SettlorIndividualPassportPage, SettlorIndividualPassportYesNoPage}
 import play.api.libs.json.JsPath
 import sections.LivingSettlors
 
@@ -48,7 +48,8 @@ final case class SettlorIndividualOrBusinessPage(index: Int) extends QuestionPag
           .flatMap(_.remove(SettlorBusinessTimeYesNoPage(index)))
           .flatMap(_.remove(LivingSettlorStatus(index)))
       case Some(Business) =>
-        userAnswers.remove(SettlorIndividualNamePage(index))
+        userAnswers.remove(SettlorAliveYesNoPage(index))
+          .flatMap(_.remove(SettlorIndividualNamePage(index)))
           .flatMap(_.remove(SettlorIndividualDateOfBirthYesNoPage(index)))
           .flatMap(_.remove(SettlorIndividualDateOfBirthPage(index)))
           .flatMap(_.remove(SettlorIndividualNINOYesNoPage(index)))

--- a/app/pages/living_settlor/individual/SettlorAliveYesNoPage.scala
+++ b/app/pages/living_settlor/individual/SettlorAliveYesNoPage.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.living_settlor.individual
+
+import models.UserAnswers
+import pages.QuestionPage
+import pages.living_settlor.individual.mld5.MentalCapacityYesNoPage
+import play.api.libs.json.JsPath
+import sections.LivingSettlors
+
+import scala.util.Try
+
+final case class SettlorAliveYesNoPage(index: Int) extends QuestionPage[Boolean] {
+
+  override def path: JsPath = LivingSettlors.path \ index \ toString
+
+  override def toString: String = "aliveAtRegistration"
+
+  override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] = {
+    value match {
+      case Some(false) =>
+        userAnswers
+          .remove(MentalCapacityYesNoPage(index))
+      case _ =>
+        super.cleanup(value, userAnswers)
+    }
+  }
+}

--- a/app/pages/trust_type/SetUpByLivingSettlorYesNoPage.scala
+++ b/app/pages/trust_type/SetUpByLivingSettlorYesNoPage.scala
@@ -23,22 +23,22 @@ import sections.{DeceasedSettlor, LivingSettlors, Settlors}
 
 import scala.util.{Success, Try}
 
-case object SetUpAfterSettlorDiedYesNoPage extends QuestionPage[Boolean] {
+case object SetUpByLivingSettlorYesNoPage extends QuestionPage[Boolean] {
 
   override def path: JsPath = Settlors.path \ toString
 
-  override def toString: String = "setUpAfterSettlorDiedYesNo"
+  override def toString: String = "setUpByLivingSettlorYesNo"
 
   override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] = {
     value match {
-      case Some(false) =>
+      case Some(true) =>
         userAnswers.get(SetUpInAdditionToWillTrustYesNoPage) match {
           case Some(true) =>
             Success(userAnswers)
           case _ =>
             userAnswers.remove(DeceasedSettlor)
         }
-      case Some(true) =>
+      case Some(false) =>
         userAnswers.remove(KindOfTrustPage)
           .flatMap(_.remove(SetUpInAdditionToWillTrustYesNoPage))
           .flatMap(_.remove(HowDeedOfVariationCreatedPage))

--- a/app/utils/print/BusinessSettlorPrintHelper.scala
+++ b/app/utils/print/BusinessSettlorPrintHelper.scala
@@ -30,7 +30,7 @@ class BusinessSettlorPrintHelper @Inject()(answerRowConverter: AnswerRowConverte
                                            trustTypePrintHelper: TrustTypePrintHelper)
   extends SettlorPrintHelper(trustTypePrintHelper, answerRowConverter) {
 
-  override def answerRows(index: Int, draftId: String)
+  override def answerRows(index: Int, draftId: String, prefix: Option[String] = None)
                          (bound: AnswerRowConverter#Bound)
                          (implicit messages: Messages): Seq[Option[AnswerRow]] = Seq(
     bound.enumQuestion(SettlorIndividualOrBusinessPage(index), "settlorIndividualOrBusiness", SettlorIndividualOrBusinessController.onPageLoad(index, draftId).url, "settlorIndividualOrBusiness"),

--- a/app/utils/print/DeceasedSettlorPrintHelper.scala
+++ b/app/utils/print/DeceasedSettlorPrintHelper.scala
@@ -28,7 +28,7 @@ class DeceasedSettlorPrintHelper @Inject()(answerRowConverter: AnswerRowConverte
                                            trustTypePrintHelper: TrustTypePrintHelper)
   extends SettlorPrintHelper(trustTypePrintHelper, answerRowConverter) {
 
-  override def answerRows(index: Int, draftId: String)
+  override def answerRows(index: Int, draftId: String, prefix: Option[String] = None)
                          (bound: AnswerRowConverter#Bound)
                          (implicit messages: Messages): Seq[Option[AnswerRow]] = Seq(
     bound.nameQuestion(SettlorsNamePage, "settlorsName", SettlorsNameController.onPageLoad(draftId).url),

--- a/app/utils/print/LivingSettlorPrintHelper.scala
+++ b/app/utils/print/LivingSettlorPrintHelper.scala
@@ -30,30 +30,36 @@ class LivingSettlorPrintHelper @Inject()(answerRowConverter: AnswerRowConverter,
                                          trustTypePrintHelper: TrustTypePrintHelper)
   extends SettlorPrintHelper(trustTypePrintHelper, answerRowConverter) {
 
-  override def answerRows(index: Int, draftId: String)
+  override def answerRows(index: Int, draftId: String, prefix: Option[String] = None)
                          (bound: AnswerRowConverter#Bound)
-                         (implicit messages: Messages): Seq[Option[AnswerRow]] = Seq(
-    bound.enumQuestion(SettlorIndividualOrBusinessPage(index), "settlorIndividualOrBusiness", SettlorIndividualOrBusinessController.onPageLoad(index, draftId).url, "settlorIndividualOrBusiness"),
-    bound.nameQuestion(SettlorIndividualNamePage(index), "settlorIndividualName", SettlorIndividualNameController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorIndividualDateOfBirthYesNoPage(index), "settlorIndividualDateOfBirthYesNo", SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, draftId).url),
-    bound.dateQuestion(SettlorIndividualDateOfBirthPage(index), "settlorIndividualDateOfBirth", SettlorIndividualDateOfBirthController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(CountryOfNationalityYesNoPage(index), "settlorIndividualCountryOfNationalityYesNo", CountryOfNationalityYesNoController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(UkCountryOfNationalityYesNoPage(index), "settlorIndividualUkCountryOfNationalityYesNo", UkCountryOfNationalityYesNoController.onPageLoad(index, draftId).url),
-    bound.countryQuestion(CountryOfNationalityPage(index), UkCountryOfNationalityYesNoPage(index), "settlorIndividualCountryOfNationality", CountryOfNationalityController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorIndividualNINOYesNoPage(index), "settlorIndividualNINOYesNo", SettlorIndividualNINOYesNoController.onPageLoad(index, draftId).url),
-    bound.ninoQuestion(SettlorIndividualNINOPage(index), "settlorIndividualNINO", SettlorIndividualNINOController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(CountryOfResidencyYesNoPage(index), "settlorIndividualCountryOfResidencyYesNo", CountryOfResidencyYesNoController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(UkCountryOfResidencyYesNoPage(index), "settlorIndividualUkCountryOfResidencyYesNo", UkCountryOfResidencyYesNoController.onPageLoad(index, draftId).url),
-    bound.countryQuestion(CountryOfResidencyPage(index), UkCountryOfResidencyYesNoPage(index), "settlorIndividualCountryOfResidency", CountryOfResidencyController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorAddressYesNoPage(index), "settlorIndividualAddressYesNo", SettlorIndividualAddressYesNoController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorAddressUKYesNoPage(index), "settlorIndividualAddressUKYesNo", SettlorIndividualAddressUKYesNoController.onPageLoad(index, draftId).url),
-    bound.addressQuestion(SettlorAddressUKPage(index), "settlorIndividualAddressUK", SettlorIndividualAddressUKController.onPageLoad(index, draftId).url),
-    bound.addressQuestion(SettlorAddressInternationalPage(index), "settlorIndividualAddressInternational", SettlorIndividualAddressInternationalController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorIndividualPassportYesNoPage(index), "settlorIndividualPassportYesNo", SettlorIndividualPassportYesNoController.onPageLoad(index, draftId).url),
-    bound.passportOrIdCardDetailsQuestion(SettlorIndividualPassportPage(index), "settlorIndividualPassport", SettlorIndividualPassportController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorIndividualIDCardYesNoPage(index), "settlorIndividualIDCardYesNo", SettlorIndividualIDCardYesNoController.onPageLoad(index, draftId).url),
-    bound.passportOrIdCardDetailsQuestion(SettlorIndividualIDCardPage(index), "settlorIndividualIDCard", SettlorIndividualIDCardController.onPageLoad(index, draftId).url),
-    bound.enumQuestion(MentalCapacityYesNoPage(index), "settlorIndividualMentalCapacityYesNo", MentalCapacityYesNoController.onPageLoad(index, draftId).url, "site")
-  )
+                         (implicit messages: Messages): Seq[Option[AnswerRow]] = {
+
+    val messageKeyPrefix = prefix.getOrElse("")
+
+    Seq(
+      bound.enumQuestion(SettlorIndividualOrBusinessPage(index), "settlorIndividualOrBusiness", SettlorIndividualOrBusinessController.onPageLoad(index, draftId).url, "settlorIndividualOrBusiness"),
+      bound.yesNoQuestion(SettlorAliveYesNoPage(index), "settlorAliveYesNo", SettlorAliveYesNoController.onPageLoad(index, draftId).url),
+      bound.nameQuestion(SettlorIndividualNamePage(index), s"settlorIndividualName$messageKeyPrefix", SettlorIndividualNameController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorIndividualDateOfBirthYesNoPage(index), "settlorIndividualDateOfBirthYesNo", SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, draftId).url),
+      bound.dateQuestion(SettlorIndividualDateOfBirthPage(index), s"settlorIndividualDateOfBirth$messageKeyPrefix", SettlorIndividualDateOfBirthController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(CountryOfNationalityYesNoPage(index), "settlorIndividualCountryOfNationalityYesNo", CountryOfNationalityYesNoController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(UkCountryOfNationalityYesNoPage(index), s"settlorIndividualUkCountryOfNationalityYesNo$messageKeyPrefix", UkCountryOfNationalityYesNoController.onPageLoad(index, draftId).url),
+      bound.countryQuestion(CountryOfNationalityPage(index), UkCountryOfNationalityYesNoPage(index), s"settlorIndividualCountryOfNationality$messageKeyPrefix", CountryOfNationalityController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorIndividualNINOYesNoPage(index), "settlorIndividualNINOYesNo", SettlorIndividualNINOYesNoController.onPageLoad(index, draftId).url),
+      bound.ninoQuestion(SettlorIndividualNINOPage(index), "settlorIndividualNINO", SettlorIndividualNINOController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(CountryOfResidencyYesNoPage(index), s"settlorIndividualCountryOfResidencyYesNo$messageKeyPrefix", CountryOfResidencyYesNoController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(UkCountryOfResidencyYesNoPage(index), s"settlorIndividualUkCountryOfResidencyYesNo$messageKeyPrefix", UkCountryOfResidencyYesNoController.onPageLoad(index, draftId).url),
+      bound.countryQuestion(CountryOfResidencyPage(index), UkCountryOfResidencyYesNoPage(index), s"settlorIndividualCountryOfResidency$messageKeyPrefix", CountryOfResidencyController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorAddressYesNoPage(index), s"settlorIndividualAddressYesNo$messageKeyPrefix", SettlorIndividualAddressYesNoController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorAddressUKYesNoPage(index), s"settlorIndividualAddressUKYesNo$messageKeyPrefix", SettlorIndividualAddressUKYesNoController.onPageLoad(index, draftId).url),
+      bound.addressQuestion(SettlorAddressUKPage(index), s"settlorIndividualAddressUK$messageKeyPrefix", SettlorIndividualAddressUKController.onPageLoad(index, draftId).url),
+      bound.addressQuestion(SettlorAddressInternationalPage(index), s"settlorIndividualAddressInternational$messageKeyPrefix", SettlorIndividualAddressInternationalController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorIndividualPassportYesNoPage(index), "settlorIndividualPassportYesNo", SettlorIndividualPassportYesNoController.onPageLoad(index, draftId).url),
+      bound.passportOrIdCardDetailsQuestion(SettlorIndividualPassportPage(index), s"settlorIndividualPassport$messageKeyPrefix", SettlorIndividualPassportController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorIndividualIDCardYesNoPage(index), "settlorIndividualIDCardYesNo", SettlorIndividualIDCardYesNoController.onPageLoad(index, draftId).url),
+      bound.passportOrIdCardDetailsQuestion(SettlorIndividualIDCardPage(index), s"settlorIndividualIDCard$messageKeyPrefix", SettlorIndividualIDCardController.onPageLoad(index, draftId).url),
+      bound.enumQuestion(MentalCapacityYesNoPage(index), "settlorIndividualMentalCapacityYesNo", MentalCapacityYesNoController.onPageLoad(index, draftId).url, "site")
+    )
+  }
 
 }

--- a/app/utils/print/SettlorPrintHelper.scala
+++ b/app/utils/print/SettlorPrintHelper.scala
@@ -32,32 +32,32 @@ abstract class SettlorPrintHelper(trustTypePrintHelper: TrustTypePrintHelper,
     answerSection(userAnswers, name, index, draftId)(headingKey, sectionKey(index))
   }
 
-  def checkDetailsSection(userAnswers: UserAnswers, name: String, draftId: String, index: Int = 0)
+  def checkDetailsSection(userAnswers: UserAnswers, name: String, draftId: String, index: Int = 0, prefix: Option[String] = None)
                          (implicit messages: Messages): AnswerSection = {
-    answerSection(userAnswers, name, index, draftId)(None, None)
+    answerSection(userAnswers, name, index, draftId, prefix)(None, None)
   }
 
-  private def answerSection(userAnswers: UserAnswers, name: String, index: Int, draftId: String)
+  private def answerSection(userAnswers: UserAnswers, name: String, index: Int, draftId: String, prefix: Option[String] = None)
                            (heading: Option[String], section: Option[String])
                            (implicit messages: Messages): AnswerSection = {
     AnswerSection(
       headingKey = heading,
-      rows = answerRows(userAnswers, name, index, draftId),
+      rows = answerRows(userAnswers, name, index, draftId, prefix),
       sectionKey = section,
       headingArgs = Seq(index + 1)
     )
   }
 
-  private def answerRows(userAnswers: UserAnswers, name: String, index: Int, draftId: String)
+  private def answerRows(userAnswers: UserAnswers, name: String, index: Int, draftId: String, prefix: Option[String])
                         (implicit messages: Messages): Seq[AnswerRow] = {
 
     val bound = answerRowConverter.bind(userAnswers, name)
 
     trustTypePrintHelper.answerRows(userAnswers, draftId) ++
-      answerRows(index, draftId)(bound).flatten
+      answerRows(index, draftId, prefix)(bound).flatten
   }
 
-  def answerRows(index: Int, draftId: String)
+  def answerRows(index: Int, draftId: String, prefix: Option[String] = None)
                 (bound: AnswerRowConverter#Bound)
                 (implicit messages: Messages): Seq[Option[AnswerRow]]
 

--- a/app/utils/print/TrustTypePrintHelper.scala
+++ b/app/utils/print/TrustTypePrintHelper.scala
@@ -31,7 +31,7 @@ class TrustTypePrintHelper @Inject()(answerRowConverter: AnswerRowConverter) {
     val bound: answerRowConverter.Bound = answerRowConverter.bind(userAnswers)
 
     Seq(
-      bound.yesNoQuestion(SetUpAfterSettlorDiedYesNoPage, "setUpAfterSettlorDiedYesNo", SetUpAfterSettlorDiedController.onPageLoad(draftId).url),
+      bound.yesNoQuestion(SetUpByLivingSettlorYesNoPage, "setUpByLivingSettlorYesNo", SetUpByLivingSettlorController.onPageLoad(draftId).url),
       bound.enumQuestion(KindOfTrustPage, "kindOfTrust", KindOfTrustController.onPageLoad(draftId).url, "kindOfTrust"),
       bound.yesNoQuestion(SetUpInAdditionToWillTrustYesNoPage, "setUpInAdditionToWillTrustYesNo", AdditionToWillTrustYesNoController.onPageLoad(draftId).url),
       bound.enumQuestion(HowDeedOfVariationCreatedPage, "howDeedOfVariationCreated", HowDeedOfVariationCreatedController.onPageLoad(draftId).url, "howDeedOfVariationCreated"),

--- a/app/views/components/InputYesNo.scala.html
+++ b/app/views/components/InputYesNo.scala.html
@@ -21,7 +21,9 @@
     label: String,
     hint: Option[String] = None,
     legendClass: Option[String] = None,
-    legendAsHeading: Boolean = true
+    legendAsHeading: Boolean = true,
+    yesContent: String = "site.yes",
+    noContent: String = "site.no"
 )(implicit messages: Messages)
 
 @govukRadios(Radios(
@@ -45,13 +47,13 @@
             id = Some(field.id + "-yes"),
             value = Some("true"),
             checked = field.value.contains("true"),
-            content = Text(messages("site.yes"))
+            content = Text(messages(yesContent))
         ),
         RadioItem(
             id = Some(field.id + "-no"),
             value = Some("false"),
             checked = field.value.contains("false"),
-            content = Text(messages("site.no"))
+            content = Text(messages(noContent))
         )
     )
 ))

--- a/app/views/living_settlor/individual/SettlorAliveYesNoView.scala.html
+++ b/app/views/living_settlor/individual/SettlorAliveYesNoView.scala.html
@@ -1,0 +1,49 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.living_settlor.individual.routes.SettlorAliveYesNoController
+@import views.html.components.{SubmitButton, ErrorSummary, InputYesNo}
+
+@this(
+    main_template: MainTemplate,
+    formHelper: FormWithCSRF,
+    submitButton: SubmitButton,
+    error_summary: ErrorSummary,
+    inputYesNo: InputYesNo
+)
+
+@(form: Form[_], draftId: String, index: Int)(implicit request: Request[_], messages: Messages)
+
+
+@main_template(
+    title = s"${errorPrefix(form)}${messages("settlorAliveYesNo.title")}",
+    showBackLink = true
+) {
+
+    @formHelper(action = SettlorAliveYesNoController.onSubmit(index, draftId), 'autoComplete -> "off") {
+
+    @error_summary(form.errors)
+
+    @inputYesNo(
+        field = form("value"),
+        label = messages("settlorAliveYesNo.title"),
+        legendClass = Some("govuk-heading-l"),
+        legendAsHeading = true
+    )
+
+    @submitButton()
+    }
+}

--- a/app/views/living_settlor/individual/SettlorIndividualAddressInternationalView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualAddressInternationalView.scala.html
@@ -27,10 +27,19 @@
     internationalAddress: InternationalAddress
 )
 
-@(form: Form[_], countryOptions:Seq[InputOption], index:Int, draftId: String, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], countryOptions:Seq[InputOption], index:Int, draftId: String, name: FullName,
+settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualAddressInternationalPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualAddressInternational"
+    } else {
+        "settlorIndividualAddressInternationalPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualAddressInternational.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualAddressInternationalPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -40,7 +49,7 @@
 
         @internationalAddress(
             form = form,
-            legend = messages("settlorIndividualAddressInternational.heading", name.toString),
+            legend = messages(s"${settlorIndividualAddressInternationalPrefix}.heading", name.toString),
             legendAsHeading = true,
             countryOptions = countryOptions
         )

--- a/app/views/living_settlor/individual/SettlorIndividualAddressUKView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualAddressUKView.scala.html
@@ -26,10 +26,18 @@
     ukAddress: UkAddress
 )
 
-@(form: Form[_], draftId: String, index: Int, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], draftId: String, index: Int, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualAddressUKPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualAddressUK"
+    } else {
+        "settlorIndividualAddressUKPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualAddressUK.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualAddressUKPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -37,7 +45,7 @@
 
         @error_summary(form.errors)
 
-        @ukAddress(form, messages("settlorIndividualAddressUK.heading", name.toString))
+        @ukAddress(form, messages(s"${settlorIndividualAddressUKPrefix}.heading", name.toString))
 
         @submitButton()
     }

--- a/app/views/living_settlor/individual/SettlorIndividualAddressUKYesNoView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualAddressUKYesNoView.scala.html
@@ -26,10 +26,18 @@
     inputYesNo: InputYesNo
 )
 
-@(form: Form[_], draftId: String, index: Int, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], draftId: String, index: Int, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualAddressUKYesNoPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualAddressUKYesNo"
+    } else {
+        "settlorIndividualAddressUKYesNoPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualAddressUKYesNo.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualAddressUKYesNoPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +47,7 @@
 
         @inputYesNo(
             field = form("value"),
-            label = messages("settlorIndividualAddressUKYesNo.heading", name),
+            label = messages(s"${settlorIndividualAddressUKYesNoPrefix}.heading", name),
             legendClass = Some("govuk-heading-l"),
             legendAsHeading = true
         )

--- a/app/views/living_settlor/individual/SettlorIndividualAddressYesNoView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualAddressYesNoView.scala.html
@@ -26,10 +26,18 @@
     inputYesNo: InputYesNo
 )
 
-@(form: Form[_], draftId: String, index: Int, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], draftId: String, index: Int, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualAddressYesNoPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualAddressYesNo"
+    } else {
+        "settlorIndividualAddressYesNoPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualAddressYesNo.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualAddressYesNoPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +47,7 @@
 
         @inputYesNo(
             field = form("value"),
-            label = messages("settlorIndividualAddressYesNo.heading", name.toString),
+            label = messages(s"${settlorIndividualAddressYesNoPrefix}.heading", name.toString),
             legendClass = Some("govuk-heading-l"),
             legendAsHeading = true
         )

--- a/app/views/living_settlor/individual/SettlorIndividualDateOfBirthView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualDateOfBirthView.scala.html
@@ -26,10 +26,18 @@
     input_date: InputDate
 )
 
-@(form: Form[_], draftId: String, index: Int, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], draftId: String, index: Int, name: FullName, setUpBeforeSettlorDied: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualDateOfBirthPrefix = @{
+    if({{setUpBeforeSettlorDied}}){
+        "settlorIndividualDateOfBirth"
+    } else {
+        "settlorIndividualDateOfBirthPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualDateOfBirth.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualDateOfBirthPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +47,7 @@
 
         @input_date(
             field = form("value"),
-            legend = messages("settlorIndividualDateOfBirth.heading", name),
+            legend = messages(s"${settlorIndividualDateOfBirthPrefix}.heading", name),
             legendClass = "govuk-heading-l",
             legendAsHeading = true,
             hint = Some(messages(s"site.date.hint"))

--- a/app/views/living_settlor/individual/SettlorIndividualIDCardView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualIDCardView.scala.html
@@ -30,10 +30,18 @@
     select: InputSelect
 )
 
-@(form: Form[_], countryOptions:Seq[InputOption], draftId: String, index: Int, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], countryOptions:Seq[InputOption], draftId: String, index: Int, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualIDCardPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualIDCard"
+    } else {
+        "settlorIndividualIDCardPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualIDCard.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualIDCardPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -41,10 +49,10 @@
 
         @error_summary(form.errors)
 
-        @heading("settlorIndividualIDCard.heading", Some(name.toString))
+        @heading(s"${settlorIndividualIDCardPrefix}.heading", Some(name.toString))
 
         @select(field = form("country"),
-            label = messages("settlorIndividualIDCard.country"),
+            label = messages(s"${settlorIndividualIDCardPrefix}.country"),
             labelClasses = Set("bold"),
             options = countryOptions,
             placeholder = Some(messages("site.address.country.select")),
@@ -55,15 +63,15 @@
         @inputText(
             field = form("number"),
             inputClass = Some("govuk-input--width-20"),
-            label = messages("settlorIndividualIDCard.number")
+            label = messages(s"${settlorIndividualIDCardPrefix}.number")
         )
 
         @input_date(
             field = form("expiryDate"),
-            legend = messages("settlorIndividualIDCard.expiryDate.title"),
+            legend = messages(s"${settlorIndividualIDCardPrefix}.expiryDate.title"),
             legendClass = "bold",
             legendAsHeading = false,
-            hint = Some(messages(s"settlorIndividualIDCard.expiryDate.hint"))
+            hint = Some(messages(s"${settlorIndividualIDCardPrefix}.expiryDate.hint"))
         )
 
         @submitButton()

--- a/app/views/living_settlor/individual/SettlorIndividualNameView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualNameView.scala.html
@@ -26,13 +26,20 @@
     heading: Heading
 )
 
-@(form: Form[_], draftId: String, index: Int)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], draftId: String, index: Int, setUpBeforeSettlorDied: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualNamePrefix = @{
+    if({{setUpBeforeSettlorDied}}){
+         "settlorIndividualName"
+    } else {
+        "settlorIndividualNamePastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualName.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualNamePrefix}.title")}",
     showBackLink = true
 ) {
-
     @formHelper(action = SettlorIndividualNameController.onSubmit(index, draftId), 'autoComplete -> "on") {
 
         @error_summary(form.errors)
@@ -40,26 +47,26 @@
     <fieldset class="govuk-fieldset">
 
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            @heading("settlorIndividualName.heading")
+            @heading(s"${settlorIndividualNamePrefix}.heading")
         </legend>
 
         @inputText(
             field = form("firstName"),
-            label = messages("settlorIndividualName.firstName"),
+            label = messages(s"${settlorIndividualNamePrefix}.firstName"),
             inputClass = Some("govuk-!-width-one-half"),
             autocomplete = Some("given-name")
         )
 
         @inputText(
             field = form("middleName"),
-            label = messages("settlorIndividualName.middleName"),
+            label = messages(s"${settlorIndividualNamePrefix}.middleName"),
             inputClass = Some("govuk-!-width-one-half"),
             autocomplete = Some("additional-name")
         )
 
         @inputText(
             field = form("lastName"),
-            label = messages("settlorIndividualName.lastName"),
+            label = messages(s"${settlorIndividualNamePrefix}.lastName"),
             inputClass = Some("govuk-!-width-one-half"),
             autocomplete = Some("family-name")
         )

--- a/app/views/living_settlor/individual/SettlorIndividualPassportView.scala.html
+++ b/app/views/living_settlor/individual/SettlorIndividualPassportView.scala.html
@@ -30,10 +30,18 @@
     select: InputSelect
 )
 
-@(form: Form[_], countryOptions:Seq[InputOption], draftId: String, index: Int, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], countryOptions:Seq[InputOption], draftId: String, index: Int, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualPassportPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualPassport"
+    } else {
+        "settlorIndividualPassportPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualPassport.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualPassportPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -41,10 +49,10 @@
 
         @error_summary(form.errors)
 
-        @heading("settlorIndividualPassport.heading", Some(name.toString))
+        @heading(s"${settlorIndividualPassportPrefix}.heading", Some(name.toString))
 
         @select(field = form("country"),
-            label = messages("settlorIndividualPassport.country"),
+            label = messages(s"${settlorIndividualPassportPrefix}.country"),
             labelClasses = Set("bold"),
             options = countryOptions,
             placeholder = Some(messages("site.address.country.select")),
@@ -55,16 +63,16 @@
         @inputText(
             field = form("number"),
             inputClass = Some("govuk-input--width-20"),
-            label = messages("settlorIndividualPassport.number"),
-            hint = Some(messages(s"settlorIndividualPassport.number.hint"))
+            label = messages(s"${settlorIndividualPassportPrefix}.number"),
+            hint = Some(messages(s"${settlorIndividualPassportPrefix}.number.hint"))
         )
 
         @input_date(
             field = form("expiryDate"),
-            legend = messages("settlorIndividualPassport.expiryDate.title"),
+            legend = messages(s"${settlorIndividualPassportPrefix}.expiryDate.title"),
             legendClass = "bold",
             legendAsHeading = false,
-            hint = Some(messages(s"settlorIndividualPassport.expiryDate.hint"))
+            hint = Some(messages(s"${settlorIndividualPassportPrefix}.expiryDate.hint"))
         )
 
         @submitButton()

--- a/app/views/living_settlor/individual/mld5/CountryOfNationalityView.scala.html
+++ b/app/views/living_settlor/individual/mld5/CountryOfNationalityView.scala.html
@@ -27,10 +27,19 @@
     select: InputSelect
 )
 
-@(form: Form[_], index: Int, draftId: String, countryOptions: Seq[InputOption], name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], index: Int, draftId: String, countryOptions: Seq[InputOption], name: FullName,
+settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualCountryOfNationalityPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualCountryOfNationality"
+    } else {
+        "settlorIndividualCountryOfNationalityPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualCountryOfNationality.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualCountryOfNationalityPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +48,7 @@
         @error_summary(form.errors)
 
         @select(field = form("value"),
-            label = messages("settlorIndividualCountryOfNationality.heading", name.toString),
+            label = messages(s"${settlorIndividualCountryOfNationalityPrefix}.heading", name.toString),
             labelClasses = Set("govuk-heading-l"),
             labelAsHeading = true,
             options = countryOptions,

--- a/app/views/living_settlor/individual/mld5/CountryOfResidencyView.scala.html
+++ b/app/views/living_settlor/individual/mld5/CountryOfResidencyView.scala.html
@@ -27,10 +27,19 @@
     select: InputSelect
 )
 
-@(form: Form[_], index: Int, draftId: String, countryOptions: Seq[InputOption], name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], index: Int, draftId: String, countryOptions: Seq[InputOption], name: FullName,
+settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualCountryOfResidencyPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualCountryOfResidency"
+    } else {
+        "settlorIndividualCountryOfResidencyPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualCountryOfResidency.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualCountryOfResidencyPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +48,7 @@
         @error_summary(form.errors)
 
         @select(field = form("value"),
-            label = messages("settlorIndividualCountryOfResidency.heading", name.toString),
+            label = messages(s"${settlorIndividualCountryOfResidencyPrefix}.heading", name.toString),
             labelClasses = Set("govuk-heading-l"),
             labelAsHeading = true,
             options = countryOptions,

--- a/app/views/living_settlor/individual/mld5/CountryOfResidencyYesNoView.scala.html
+++ b/app/views/living_settlor/individual/mld5/CountryOfResidencyYesNoView.scala.html
@@ -26,10 +26,18 @@
     inputYesNo: InputYesNo
 )
 
-@(form: Form[_], index: Int, draftId: String, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], index: Int, draftId: String, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualCountryOfResidencyYesNoPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualCountryOfResidencyYesNo"
+    } else {
+        "settlorIndividualCountryOfResidencyYesNoPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualCountryOfResidencyYesNo.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualCountryOfResidencyYesNoPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,9 +47,9 @@
 
         @inputYesNo(
             field = form("value"),
-            label = messages("settlorIndividualCountryOfResidencyYesNo.heading", name.toString),
+            label = messages(s"${settlorIndividualCountryOfResidencyYesNoPrefix}.heading", name.toString),
             legendClass = Some("govuk-heading-l"),
-            hint = Some(messages("settlorIndividualCountryOfResidencyYesNo.hint"))
+            hint = Some(messages(s"${settlorIndividualCountryOfResidencyYesNoPrefix}.hint"))
         )
 
         @submitButton()

--- a/app/views/living_settlor/individual/mld5/UkCountryOfNationalityYesNoView.scala.html
+++ b/app/views/living_settlor/individual/mld5/UkCountryOfNationalityYesNoView.scala.html
@@ -26,10 +26,18 @@
     inputYesNo: InputYesNo
 )
 
-@(form: Form[_], index: Int, draftId: String, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], index: Int, draftId: String, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualUkCountryOfNationalityYesNoPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualUkCountryOfNationalityYesNo"
+    } else {
+        "settlorIndividualUkCountryOfNationalityYesNoPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualUkCountryOfNationalityYesNo.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualUkCountryOfNationalityYesNoPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +47,7 @@
 
         @inputYesNo(
             field = form("value"),
-            label = messages("settlorIndividualUkCountryOfNationalityYesNo.heading", name.toString),
+            label = messages(s"${settlorIndividualUkCountryOfNationalityYesNoPrefix}.heading", name.toString),
             legendClass = Some("govuk-heading-l")
         )
 

--- a/app/views/living_settlor/individual/mld5/UkCountryOfResidencyYesNoView.scala.html
+++ b/app/views/living_settlor/individual/mld5/UkCountryOfResidencyYesNoView.scala.html
@@ -26,10 +26,18 @@
     inputYesNo: InputYesNo
 )
 
-@(form: Form[_], index: Int, draftId: String, name: FullName)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], index: Int, draftId: String, name: FullName, settlorAliveAtRegistration: Boolean)(implicit request: Request[_], messages: Messages)
+
+@settlorIndividualUkCountryOfResidencyYesNoPrefix = @{
+    if(settlorAliveAtRegistration){
+        "settlorIndividualUkCountryOfResidencyYesNo"
+    } else {
+        "settlorIndividualUkCountryOfResidencyYesNoPastTense"
+    }
+}
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("settlorIndividualUkCountryOfResidencyYesNo.title")}",
+    title = s"${errorPrefix(form)}${messages(s"${settlorIndividualUkCountryOfResidencyYesNoPrefix}.title")}",
     showBackLink = true
 ) {
 
@@ -39,7 +47,7 @@
 
         @inputYesNo(
             field = form("value"),
-            label = messages("settlorIndividualUkCountryOfResidencyYesNo.heading", name.toString),
+            label = messages(s"${settlorIndividualUkCountryOfResidencyYesNoPrefix}.heading", name.toString),
             legendClass = Some("govuk-heading-l")
         )
 

--- a/app/views/trust_type/SetUpByLivingSettlorView.scala.html
+++ b/app/views/trust_type/SetUpByLivingSettlorView.scala.html
@@ -28,20 +28,21 @@
 @(form: Form[_], draftId: String, isTaxable: Boolean)(implicit request: Request[_], messages: Messages)
 
 @main_template(
-    title = s"${errorPrefix(form)}${messages("setUpAfterSettlorDiedYesNo.title")}",
+    title = s"${errorPrefix(form)}${messages("setUpByLivingSettlorYesNo.title")}",
     showBackLink = true
 ) {
 
-    @formHelper(action = SetUpAfterSettlorDiedController.onSubmit(draftId), 'autoComplete -> "off") {
+    @formHelper(action = SetUpByLivingSettlorController.onSubmit(draftId), 'autoComplete -> "off") {
 
         @error_summary(form.errors)
 
         @inputYesNo(
             field = form("value"),
-            label = messages("setUpAfterSettlorDiedYesNo.heading"),
+            label = messages("setUpByLivingSettlorYesNo.heading"),
             legendClass = Some("govuk-heading-l"),
             legendAsHeading = true,
-            hint = if(isTaxable) Some(messages("setUpAfterSettlorDiedYesNo.hint")) else None
+            yesContent = "setUpByLivingSettlorYesNo.yes",
+            noContent = "setUpByLivingSettlorYesNo.no"
         )
 
         @submitButton()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -33,8 +33,8 @@ POST       /:draftId/:index/remove-yes-no                                       
 
 # Trust type
 
-GET        /:draftId/setup-after-settlor-died                                               controllers.trust_type.SetUpAfterSettlorDiedController.onPageLoad(draftId: String)
-POST       /:draftId/setup-after-settlor-died                                               controllers.trust_type.SetUpAfterSettlorDiedController.onSubmit(draftId: String)
+GET        /:draftId/setup-after-settlor-died                                               controllers.trust_type.SetUpByLivingSettlorController.onPageLoad(draftId: String)
+POST       /:draftId/setup-after-settlor-died                                               controllers.trust_type.SetUpByLivingSettlorController.onSubmit(draftId: String)
 
 GET        /:draftId/in-addition-to-will-trust                                              controllers.trust_type.AdditionToWillTrustYesNoController.onPageLoad(draftId: String)
 POST       /:draftId/in-addition-to-will-trust                                              controllers.trust_type.AdditionToWillTrustYesNoController.onSubmit(draftId: String)
@@ -116,6 +116,9 @@ GET        /:draftId/living/:index/individual-or-business                       
 POST       /:draftId/living/:index/individual-or-business                                   controllers.living_settlor.SettlorIndividualOrBusinessController.onSubmit(index: Int, draftId: String)
 
 ## Individual
+
+GET        /:draftId/living/:index/individual/settlor-alive                                 controllers.living_settlor.individual.SettlorAliveYesNoController.onPageLoad(index: Int, draftId: String)
+POST       /:draftId/living/:index/individual/settlor-alive                                 controllers.living_settlor.individual.SettlorAliveYesNoController.onSubmit(index: Int, draftId: String)
 
 GET        /:draftId/living/:index/individual/name                                          controllers.living_settlor.individual.SettlorIndividualNameController.onPageLoad(index: Int, draftId: String)
 POST       /:draftId/living/:index/individual/name                                          controllers.living_settlor.individual.SettlorIndividualNameController.onSubmit(index: Int, draftId: String)

--- a/conf/messages
+++ b/conf/messages
@@ -161,6 +161,11 @@ removeSettlor.heading = Are you sure you want to remove {0}?
 removeSettlor.checkYourAnswersLabel = Are you sure you want to remove {0}?
 removeSettlor.error.required = Select yes if you want to remove the settlor
 
+settlorAliveYesNo.title = Is the settlor alive at the time of registration?
+settlorAliveYesNo.heading = Is the settlor alive at the time of registration?
+settlorAliveYesNo.error.required = Select yes if the settlor is alive
+settlorAliveYesNo.checkYourAnswersLabel = Is the settlor alive at the time of registration?
+
 5mld.countryOfResidenceYesNo.title = Do you know the settlor’s last known country of residence?
 5mld.countryOfResidenceYesNo.heading = Do you know {0}’s last known country of residence?
 5mld.countryOfResidenceYesNo.checkYourAnswersLabel = Do you know {0}’s last known country of residence?
@@ -276,11 +281,12 @@ settlorsUKAddress.title = What is the settlor’s last known address?
 settlorsUKAddress.heading = What is {0}’s last known address?
 settlorsUKAddress.checkYourAnswersLabel = What is {0}’s last known address?
 
-setUpAfterSettlorDiedYesNo.title = Was the trust set up after the settlor died?
-setUpAfterSettlorDiedYesNo.heading = Was the trust set up after the settlor died?
-setUpAfterSettlorDiedYesNo.checkYourAnswersLabel = Was the trust set up after the settlor died?
-setUpAfterSettlorDiedYesNo.error.required = Select yes if the trust was set up after the settlor died
-setUpAfterSettlorDiedYesNo.hint = This is also known as a will trust.
+setUpByLivingSettlorYesNo.title = Was the trust set up by a living settlor?
+setUpByLivingSettlorYesNo.heading = Was the trust set up by a living settlor?
+setUpByLivingSettlorYesNo.checkYourAnswersLabel = Was the trust set up by a living settlor?
+setUpByLivingSettlorYesNo.error.required = Select yes if the trust was set up by a living settlor
+setUpByLivingSettlorYesNo.yes = Yes, the trust was set up by a living settlor
+setUpByLivingSettlorYesNo.no = No, it is a ''will trust'' or a trust set up after the settlor died
 
 setUpInAdditionToWillTrustYesNo.title = Is this in addition to a will trust?
 setUpInAdditionToWillTrustYesNo.heading = Is this in addition to a will trust?
@@ -317,6 +323,21 @@ settlorIndividualName.error.firstname.invalid = Settlor’s first name must only
 settlorIndividualName.error.middlename.invalid = Settlor’s middle names must only include letters a to z, numbers 0 to 9, ampersands (&), apostrophes, commas, forward slashes, full stops, hyphens, round brackets and spaces
 settlorIndividualName.error.lastname.invalid = Settlor’s last name must only include letters a to z, numbers 0 to 9, ampersands (&), apostrophes, commas, forward slashes, full stops, hyphens, round brackets and spaces
 
+settlorIndividualNamePastTense.title = What was the settlor’s name?
+settlorIndividualNamePastTense.heading = What was the settlor’s name?
+settlorIndividualNamePastTense.checkYourAnswersLabel = What was the settlor’s name?
+settlorIndividualNamePastTense.firstName = First name
+settlorIndividualNamePastTense.middleName = Middle names (optional)
+settlorIndividualNamePastTense.lastName = Last name
+settlorIndividualNamePastTense.error.firstname.required = Enter the settlor’s first name
+settlorIndividualNamePastTense.error.lastname.required = Enter the settlor’s last name
+settlorIndividualNamePastTense.error.firstname.length = Settlor’s first name must be 35 characters or less
+settlorIndividualNamePastTense.error.middlename.length = Settlor’s middle names must be 35 characters or less
+settlorIndividualNamePastTense.error.lastname.length = Settlor’s last name must be 35 characters or less
+settlorIndividualNamePastTense.error.firstname.invalid = Settlor’s first name must only include letters a to z, numbers 0 to 9, ampersands (&), apostrophes, commas, forward slashes, full stops, hyphens, round brackets and spaces
+settlorIndividualNamePastTense.error.middlename.invalid = Settlor’s middle names must only include letters a to z, numbers 0 to 9, ampersands (&), apostrophes, commas, forward slashes, full stops, hyphens, round brackets and spaces
+settlorIndividualNamePastTense.error.lastname.invalid = Settlor’s last name must only include letters a to z, numbers 0 to 9, ampersands (&), apostrophes, commas, forward slashes, full stops, hyphens, round brackets and spaces
+
 settlorIndividualDateOfBirthYesNo.title = Do you know the settlor’s date of birth?
 settlorIndividualDateOfBirthYesNo.heading = Do you know {0}’s date of birth?
 settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel = Do you know {0}’s date of birth?
@@ -326,6 +347,11 @@ settlorIndividualDateOfBirth.title = What is the settlor’s date of birth?
 settlorIndividualDateOfBirth.heading = What is {0}’s date of birth?
 settlorIndividualDateOfBirth.checkYourAnswersLabel = What is {0}’s date of birth?
 settlorIndividualDateOfBirth.hint = For example, 31 3 1980.
+
+settlorIndividualDateOfBirthPastTense.title = What was the settlor’s date of birth?
+settlorIndividualDateOfBirthPastTense.heading = What was {0}’s date of birth?
+settlorIndividualDateOfBirthPastTense.checkYourAnswersLabel = What was {0}’s date of birth?
+settlorIndividualDateOfBirthPastTense.hint = For example, 31 3 1980.
 
 dateOfBirth.error.required.all = Enter a date of birth
 dateOfBirth.error.required.two = The date of birth must include {0} and {1}
@@ -345,6 +371,11 @@ settlorIndividualUkCountryOfNationalityYesNo.heading = Does {0} have UK national
 settlorIndividualUkCountryOfNationalityYesNo.checkYourAnswersLabel = Does {0} have UK nationality?
 settlorIndividualUkCountryOfNationalityYesNo.error.required = Select yes if the settlor has UK nationality
 
+settlorIndividualUkCountryOfNationalityYesNoPastTense.title = Did the settlor have UK nationality?
+settlorIndividualUkCountryOfNationalityYesNoPastTense.heading = Did {0} have UK nationality?
+settlorIndividualUkCountryOfNationalityYesNoPastTense.checkYourAnswersLabel = Did {0} have UK nationality?
+settlorIndividualUkCountryOfNationalityYesNoPastTense.error.required = Select yes if the settlor had UK nationality
+
 settlorIndividualCountryOfNationality.title = What is the settlor’s country of nationality?
 settlorIndividualCountryOfNationality.heading = What is {0}’s country of nationality?
 settlorIndividualCountryOfNationality.checkYourAnswersLabel = What is {0}’s country of nationality?
@@ -352,16 +383,34 @@ settlorIndividualCountryOfNationality.error.required = Enter a country
 settlorIndividualCountryOfNationality.error.length = The country of nationality must be 100 characters or less
 settlorIndividualCountryOfNationality.error.invalidCharacters = The country of nationality must only include letters a to z, apostrophes, commas, full stops, hyphens, round brackets and spaces
 
+settlorIndividualCountryOfNationalityPastTense.title = What was the settlor’s country of nationality?
+settlorIndividualCountryOfNationalityPastTense.heading = What was {0}’s country of nationality?
+settlorIndividualCountryOfNationalityPastTense.checkYourAnswersLabel = What was {0}’s country of nationality?
+settlorIndividualCountryOfNationalityPastTense.error.required = Enter a country
+settlorIndividualCountryOfNationalityPastTense.error.length = The country of nationality must be 100 characters or less
+settlorIndividualCountryOfNationalityPastTense.error.invalidCharacters = The country of nationality must only include letters a to z, apostrophes, commas, full stops, hyphens, round brackets and spaces
+
 settlorIndividualCountryOfResidencyYesNo.title = Do you know the settlor’s country of residence?
 settlorIndividualCountryOfResidencyYesNo.heading = Do you know {0}’s country of residence?
 settlorIndividualCountryOfResidencyYesNo.checkYourAnswersLabel = Do you know {0}’s country of residence?
 settlorIndividualCountryOfResidencyYesNo.hint = The country of residence is usually where the settlor lives and works most of the time during the tax year.
 settlorIndividualCountryOfResidencyYesNo.error.required = Select yes if you know the settlor’s country of residence
 
+settlorIndividualCountryOfResidencyYesNoPastTense.title = Do you know the settlor’s last known country of residence?
+settlorIndividualCountryOfResidencyYesNoPastTense.heading = Do you know {0}’s last known country of residence?
+settlorIndividualCountryOfResidencyYesNoPastTense.checkYourAnswersLabel = Do you know {0}’s last known country of residence?
+settlorIndividualCountryOfResidencyYesNoPastTense.hint = The last known country of residence is usually where the settlor lived and worked most of the time during the tax year.
+settlorIndividualCountryOfResidencyYesNoPastTense.error.required = Select yes if you know the settlor’s last known country of residence
+
 settlorIndividualUkCountryOfResidencyYesNo.title = Is the settlor a UK resident?
 settlorIndividualUkCountryOfResidencyYesNo.heading = Is {0} a UK resident?
 settlorIndividualUkCountryOfResidencyYesNo.checkYourAnswersLabel = Is {0} a UK resident?
 settlorIndividualUkCountryOfResidencyYesNo.error.required = Select yes if the settlor is a UK resident
+
+settlorIndividualUkCountryOfResidencyYesNoPastTense.title = Was the settlor a UK resident?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.heading = Was {0} a UK resident?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.checkYourAnswersLabel = Was {0} a UK resident?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.error.required = Select yes if the settlor was a UK resident
 
 settlorIndividualCountryOfResidency.title = What is the settlor’s country of residence?
 settlorIndividualCountryOfResidency.heading = What is {0}’s country of residence?
@@ -369,6 +418,13 @@ settlorIndividualCountryOfResidency.checkYourAnswersLabel = What is {0}’s coun
 settlorIndividualCountryOfResidency.error.required = Enter a country
 settlorIndividualCountryOfResidency.error.length = The country of residence must be 100 characters or less
 settlorIndividualCountryOfResidency.error.invalidCharacters = The country of residence must only include letters a to z, apostrophes, commas, full stops, hyphens, round brackets and spaces
+
+settlorIndividualCountryOfResidencyPastTense.title = What was the settlor’s country of residence?
+settlorIndividualCountryOfResidencyPastTense.heading = What was {0}’s country of residence?
+settlorIndividualCountryOfResidencyPastTense.checkYourAnswersLabel = What was {0}’s country of residence?
+settlorIndividualCountryOfResidencyPastTense.error.required = Enter a country
+settlorIndividualCountryOfResidencyPastTense.error.length = The country of residence must be 100 characters or less
+settlorIndividualCountryOfResidencyPastTense.error.invalidCharacters = The country of residence must only include letters a to z, apostrophes, commas, full stops, hyphens, round brackets and spaces
 
 settlorIndividualMentalCapacityYesNo.title = Does the settlor have mental capacity at the time of registration?
 settlorIndividualMentalCapacityYesNo.heading = Does {0} have mental capacity at the time of registration?
@@ -395,6 +451,11 @@ settlorIndividualAddressYesNo.heading = Do you know {0}’s address?
 settlorIndividualAddressYesNo.checkYourAnswersLabel = Do you know {0}’s address?
 settlorIndividualAddressYesNo.error.required = Select yes if you know the settlor’s address
 
+settlorIndividualAddressYesNoPastTense.title = Do you know the settlor’s last known address?
+settlorIndividualAddressYesNoPastTense.heading = Do you know {0}’s last known address?
+settlorIndividualAddressYesNoPastTense.checkYourAnswersLabel = Do you know {0}’s last known address?
+settlorIndividualAddressYesNoPastTense.error.required = Select yes if you know the settlor’s last known address
+
 settlorIndividualNINO.title = What is the settlor’s National Insurance number?
 settlorIndividualNINO.heading = What is {0}’s National Insurance number?
 settlorIndividualNINO.checkYourAnswersLabel = What is {0}’s National Insurance number?
@@ -412,14 +473,27 @@ settlorIndividualAddressInternational.title = What is the settlor’s address?
 settlorIndividualAddressInternational.heading = What is {0}’s address?
 settlorIndividualAddressInternational.checkYourAnswersLabel = What is {0}’s address?
 
+settlorIndividualAddressInternationalPastTense.title = What is the settlor’s last known address?
+settlorIndividualAddressInternationalPastTense.heading = What is {0}’s last known address?
+settlorIndividualAddressInternationalPastTense.checkYourAnswersLabel = What is {0}’s last known address?
+
 settlorIndividualAddressUK.title = What is the settlor’s address?
 settlorIndividualAddressUK.heading = What is {0}’s address?
 settlorIndividualAddressUK.checkYourAnswersLabel = What is {0}’s address?
+
+settlorIndividualAddressUKPastTense.title = What is the settlor’s last known address?
+settlorIndividualAddressUKPastTense.heading = What is {0}’s last known address?
+settlorIndividualAddressUKPastTense.checkYourAnswersLabel = What is {0}’s last known address?
 
 settlorIndividualAddressUKYesNo.title = Does the settlor live in the UK?
 settlorIndividualAddressUKYesNo.heading = Does {0} live in the UK?
 settlorIndividualAddressUKYesNo.checkYourAnswersLabel = Does {0} live in the UK?
 settlorIndividualAddressUKYesNo.error.required = Select yes if the settlor lives in the UK
+
+settlorIndividualAddressUKYesNoPastTense.title = Was the settlor’s last known address in the UK?
+settlorIndividualAddressUKYesNoPastTense.heading = Was {0} last known address in the UK?
+settlorIndividualAddressUKYesNoPastTense.checkYourAnswersLabel = Was {0} last known address in the UK?
+settlorIndividualAddressUKYesNoPastTense.error.required = Select yes if the settlor’s last known address was in the UK
 
 settlorIndividualIDCard.title = What are the settlor’s ID card details?
 settlorIndividualIDCard.heading = What are {0}’s ID card details?
@@ -440,6 +514,26 @@ settlorIndividualIDCard.expiryDate.error.required = ID card expiry date must inc
 settlorIndividualIDCard.expiryDate.error.invalid = Enter a real date when the settlor’s ID card expires
 settlorIndividualIDCard.expiryDate.error.future = ID card expiry date must be after 31 December 1499 and before 01 January 2100
 settlorIndividualIDCard.expiryDate.error.past = ID card expiry date must be after 31 December 1499 and before 01 January 2100
+
+settlorIndividualIDCardPastTense.title = What are the details for the settlor’s last ID card?
+settlorIndividualIDCardPastTense.heading = What are the details for {0}’s last ID card?
+settlorIndividualIDCardPastTense.checkYourAnswersLabel = What are the details for {0}’s last ID card?
+settlorIndividualIDCardPastTense.country = ID card country of issue
+settlorIndividualIDCardPastTense.error.country.required = Enter the settlor’s ID card country of issue
+settlorIndividualIDCardPastTense.country.error.required = Enter the settlor’s ID card country of issue
+settlorIndividualIDCardPastTense.country.error.length = The settlor’s ID card country must be 100 characters or less
+settlorIndividualIDCardPastTense.number = ID card number
+settlorIndividualIDCardPastTense.number.error.required = Enter the settlor’s ID card number
+settlorIndividualIDCardPastTense.number.error.length = ID card number must be 30 characters or less
+settlorIndividualIDCardPastTense.number.error.invalid = ID card number can only include letters and numbers
+settlorIndividualIDCardPastTense.expiryDate.title = Expiry date
+settlorIndividualIDCardPastTense.expiryDate.hint = Expiry date can be in the past. For example, 31 3 1980.
+settlorIndividualIDCardPastTense.expiryDate.error.required.all = Enter the ID card expiry date
+settlorIndividualIDCardPastTense.expiryDate.error.required.two = ID card expiry date must include a {0} and {1}
+settlorIndividualIDCardPastTense.expiryDate.error.required = ID card expiry date must include a {0}
+settlorIndividualIDCardPastTense.expiryDate.error.invalid = Enter a real date when the settlor’s ID card expires
+settlorIndividualIDCardPastTense.expiryDate.error.future = ID card expiry date must be after 31 December 1499 and before 01 January 2100
+settlorIndividualIDCardPastTense.expiryDate.error.past = ID card expiry date must be after 31 December 1499 and before 01 January 2100
 
 settlorIndividualIDCardYesNo.title = Do you know the settlor’s ID card details?
 settlorIndividualIDCardYesNo.heading = Do you know {0}’s ID card details?
@@ -465,6 +559,26 @@ settlorIndividualPassport.expiryDate.error.required = Passport expiry date must 
 settlorIndividualPassport.expiryDate.error.invalid = Enter a real date when the settlor’s passport expires
 settlorIndividualPassport.expiryDate.error.future = Passport expiry date must be after 31 December 1499 and before 01 January 2100
 settlorIndividualPassport.expiryDate.error.past = Passport expiry date must be after 31 December 1499 and before 01 January 2100
+
+settlorIndividualPassportPastTense.title = What are the details for the settlor’s last passport?
+settlorIndividualPassportPastTense.heading = What are the details for {0}’s last passport?
+settlorIndividualPassportPastTense.checkYourAnswersLabel = What are the details for {0}’s last passport?
+settlorIndividualPassportPastTense.country = Passport country of issue
+settlorIndividualPassportPastTense.country.error.required = Enter the settlor’s passport country of issue
+settlorIndividualPassportPastTense.country.error.length = The settlor’s passport country must be 100 characters or less
+settlorIndividualPassportPastTense.number = Passport number
+settlorIndividualPassportPastTense.number.hint = For example, 502135326.
+settlorIndividualPassportPastTense.number.error.required = Enter the settlor’s passport number
+settlorIndividualPassportPastTense.number.error.length = Passport number must be 30 characters or less
+settlorIndividualPassportPastTense.number.error.invalid = Passport number can only include letters and numbers
+settlorIndividualPassportPastTense.expiryDate.title = Expiry date
+settlorIndividualPassportPastTense.expiryDate.hint = Expiry date can be in the past. For example, 31 3 1980.
+settlorIndividualPassportPastTense.expiryDate.error.required.all = Enter the passport expiry date
+settlorIndividualPassportPastTense.expiryDate.error.required.two = Passport expiry date must include a {0} and {1}
+settlorIndividualPassportPastTense.expiryDate.error.required = Passport expiry date must include {0}
+settlorIndividualPassportPastTense.expiryDate.error.invalid = Enter a real date when the settlor’s passport expires
+settlorIndividualPassportPastTense.expiryDate.error.future = Passport expiry date must be after 31 December 1499 and before 01 January 2100
+settlorIndividualPassportPastTense.expiryDate.error.past = Passport expiry date must be after 31 December 1499 and before 01 January 2100
 
 settlorIndividualPassportYesNo.title = Do you know the settlor’s passport details?
 settlorIndividualPassportYesNo.heading = Do you know {0}’s passport details?

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -217,6 +217,11 @@ removeSettlor.error.required = Dewiswch ‘Iawn’ os ydych am dynnu’r setlwr
 removeSettlor.heading = A ydych yn siŵr eich bod am dynnu {0}?
 removeSettlor.title = A ydych yn siŵr eich bod am dynnu’r setlwr?
 
+settlorAliveYesNo.title = A yw’r setlwr yn fyw ar adeg y cofrestru?
+settlorAliveYesNo.heading = A yw’r setlwr yn fyw ar adeg y cofrestru?
+settlorAliveYesNo.error.required = Dewiswch ‘Iawn’ os yw’r setlwr yn fyw
+settlorAliveYesNo.checkYourAnswersLabel = A yw’r setlwr yn fyw ar adeg y cofrestru?
+
 session_expired.guidance = Mae hyn oherwydd eich bod wedi bod yn segur ar y gwasanaeth ers 15 munud.
 session_expired.guidance.2 = Bydd angen i chi fewngofnodi er mwyn mynd yn eich blaen i gofrestru’r ymddiriedolaeth.
 session_expired.heading = Er eich diogelwch
@@ -327,19 +332,37 @@ settlorIndividualAddressInternational.checkYourAnswersLabel = Beth yw cyfeiriad 
 settlorIndividualAddressInternational.heading = Beth yw cyfeiriad {0}?
 settlorIndividualAddressInternational.title = Beth yw cyfeiriad y setlwr?
 
+settlorIndividualAddressInternationalPastTense.title = Beth yw cyfeiriad hysbys diwethaf y setlwr?
+settlorIndividualAddressInternationalPastTense.heading = Beth yw cyfeiriad hysbys diwethaf {0}?
+settlorIndividualAddressInternationalPastTense.checkYourAnswersLabel = Beth yw cyfeiriad hysbys diwethaf {0}?
+
 settlorIndividualAddressUK.checkYourAnswersLabel = Beth yw cyfeiriad {0}?
 settlorIndividualAddressUK.heading = Beth yw cyfeiriad {0}?
 settlorIndividualAddressUK.title = Beth yw cyfeiriad y setlwr?
+
+settlorIndividualAddressUKPastTense.title = Beth yw cyfeiriad hysbys diwethaf y setlwr?
+settlorIndividualAddressUKPastTense.heading = Beth yw cyfeiriad hysbys diwethaf {0}?
+settlorIndividualAddressUKPastTense.checkYourAnswersLabel = Beth yw cyfeiriad hysbys diwethaf {0}?
 
 settlorIndividualAddressUKYesNo.checkYourAnswersLabel = A yw {0} yn byw yn y DU?
 settlorIndividualAddressUKYesNo.error.required = Dewiswch ‘Iawn’ os yw’r setlwr yn byw yn y DU
 settlorIndividualAddressUKYesNo.heading = A yw {0} yn byw yn y DU?
 settlorIndividualAddressUKYesNo.title = A yw’r setlwr yn byw yn y DU?
 
+settlorIndividualAddressUKYesNoPastTense.title = A oedd cyfeiriad hysbys diwethaf y setlwr yn y DU?
+settlorIndividualAddressUKYesNoPastTense.heading = A oedd cyfeiriad hysbys diwethaf {0} yn y DU?
+settlorIndividualAddressUKYesNoPastTense.checkYourAnswersLabel = A oedd cyfeiriad hysbys diwethaf {0} yn y DU?
+settlorIndividualAddressUKYesNoPastTense.error.required = Dewiswch ‘Iawn’ os oedd cyfeiriad hysbys diwethaf y setlwr yn y DU
+
 settlorIndividualAddressYesNo.checkYourAnswersLabel = A ydych yn gwybod cyfeiriad {0}?
 settlorIndividualAddressYesNo.error.required = Dewiswch ‘Iawn’ os ydych yn gwybod cyfeiriad y setlwr
 settlorIndividualAddressYesNo.heading = A ydych yn gwybod cyfeiriad {0}?
 settlorIndividualAddressYesNo.title = A ydych yn gwybod cyfeiriad y setlwr?
+
+settlorIndividualAddressYesNoPastTense.title = A ydych yn gwybod cyfeiriad hysbys diwethaf y setlwr?
+settlorIndividualAddressYesNoPastTense.heading = A ydych yn gwybod cyfeiriad hysbys diwethaf {0}?
+settlorIndividualAddressYesNoPastTense.checkYourAnswersLabel = A ydych yn gwybod cyfeiriad hysbys diwethaf {0}?
+settlorIndividualAddressYesNoPastTense.error.required = Dewiswch ‘Iawn’ os ydych yn gwybod cyfeiriad hysbys diwethaf y setlwr
 
 settlorIndividualCountryOfNationality.checkYourAnswersLabel = Beth yw gwlad cenedligrwydd {0}?
 settlorIndividualCountryOfNationality.error.invalidCharacters = Mae’n rhaid i wlad y cenedligrwydd gynnwys y llythrennau a i z yn unig
@@ -347,6 +370,13 @@ settlorIndividualCountryOfNationality.error.length = Mae’n rhaid i wlad y cene
 settlorIndividualCountryOfNationality.error.required = Nodwch wlad
 settlorIndividualCountryOfNationality.heading = Beth yw gwlad cenedligrwydd {0}?
 settlorIndividualCountryOfNationality.title = Beth yw gwlad cenedligrwydd y setlwr?
+
+settlorIndividualCountryOfNationalityPastTense.title = Beth oedd gwlad cenedligrwydd y setlwr?
+settlorIndividualCountryOfNationalityPastTense.heading = Beth oedd gwlad cenedligrwydd {0}?
+settlorIndividualCountryOfNationalityPastTense.checkYourAnswersLabel = Beth oedd gwlad cenedligrwydd {0}?
+settlorIndividualCountryOfNationalityPastTense.error.required = Nodwch wlad
+settlorIndividualCountryOfNationalityPastTense.error.length = Mae’n rhaid i wlad y cenedligrwydd fod yn 100 o gymeriadau neu lai
+settlorIndividualCountryOfNationalityPastTense.error.invalidCharacters = Mae’n rhaid i wlad y cenedligrwydd gynnwys y llythrennau a i z yn unig
 
 settlorIndividualCountryOfNationalityYesNo.checkYourAnswersLabel = A ydych yn gwybod gwlad cenedligrwydd {0}?
 settlorIndividualCountryOfNationalityYesNo.error.required = Dewiswch ‘Iawn’ os ydych yn gwybod gwlad cenedligrwydd y setlwr
@@ -361,16 +391,34 @@ settlorIndividualCountryOfResidency.error.required = Nodwch wlad
 settlorIndividualCountryOfResidency.heading = Beth yw gwlad breswyl {0}?
 settlorIndividualCountryOfResidency.title = Beth yw gwlad breswyl y setlwr?
 
+settlorIndividualCountryOfResidencyPastTense.title = Beth oedd gwlad breswyl y setlwr?
+settlorIndividualCountryOfResidencyPastTense.heading = Beth oedd gwlad breswyl {0}?
+settlorIndividualCountryOfResidencyPastTense.checkYourAnswersLabel = Beth oedd gwlad breswyl {0}?
+settlorIndividualCountryOfResidencyPastTense.error.required = Nodwch wlad
+settlorIndividualCountryOfResidencyPastTense.error.length = Mae’n rhaid i’r wlad breswyl fod yn 100 o gymeriadau neu lai
+settlorIndividualCountryOfResidencyPastTense.error.invalidCharacters = Mae’n rhaid i’r wlad breswyl gynnwys y llythrennau a i z yn unig
+
 settlorIndividualCountryOfResidencyYesNo.checkYourAnswersLabel = A ydych yn gwybod gwlad breswyl {0}?
 settlorIndividualCountryOfResidencyYesNo.error.required = Dewiswch ‘Iawn’ os ydych yn gwybod gwlad breswyl y setlwr
 settlorIndividualCountryOfResidencyYesNo.heading = A ydych yn gwybod gwlad breswyl {0}?
 settlorIndividualCountryOfResidencyYesNo.hint = Fel arfer, y wlad breswyl yw lle mae’r setlwr yn byw ac yn gweithio’r rhan fwyaf o’r amser yn ystod y flwyddyn dreth.
 settlorIndividualCountryOfResidencyYesNo.title = A ydych yn gwybod gwlad breswyl y setlwr?
 
+settlorIndividualCountryOfResidencyYesNoPastTense.title = A ydych yn gwybod gwlad breswyl hysbys ddiwethaf y setlwr?
+settlorIndividualCountryOfResidencyYesNoPastTense.heading = A ydych yn gwybod beth oedd gwlad breswyl hysbys ddiwethaf {0}?
+settlorIndividualCountryOfResidencyYesNoPastTense.checkYourAnswersLabel = A ydych yn gwybod beth oedd gwlad breswyl hysbys ddiwethaf {0}?
+settlorIndividualCountryOfResidencyYesNoPastTense.hint = Fel arfer, y wlad breswyl hysbys ddiwethaf yw’r man lle’r oedd y setlwr yn byw ac yn gweithio’r rhan fwyaf o’r amser yn ystod y flwyddyn dreth.
+settlorIndividualCountryOfResidencyYesNoPastTense.error.required = Dewiswch ‘Iawn’ os ydych yn gwybod beth oedd gwlad breswyl hysbys ddiwethaf y setlwr
+
 settlorIndividualDateOfBirth.checkYourAnswersLabel = Beth yw dyddiad geni {0}?
 settlorIndividualDateOfBirth.heading = Beth yw dyddiad geni {0}?
 settlorIndividualDateOfBirth.hint = Er enghraifft, 31 3 1980.
 settlorIndividualDateOfBirth.title = Beth yw dyddiad geni’r setlwr?
+
+settlorIndividualDateOfBirthPastTense.checkYourAnswersLabel = Beth oedd dyddiad geni {0}?
+settlorIndividualDateOfBirthPastTense.heading = Beth oedd dyddiad geni {0}?
+settlorIndividualDateOfBirthPastTense.hint = Er enghraifft, 31 3 1980.
+settlorIndividualDateOfBirthPastTense.title = Beth oedd dyddiad geni’r setlwr?
 
 settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel = A ydych yn gwybod dyddiad geni {0}?
 settlorIndividualDateOfBirthYesNo.error.required = Dewiswch ‘Iawn’ os ydych yn gwybod y dyddiad geni
@@ -396,6 +444,26 @@ settlorIndividualIDCard.number.error.invalid = Gall rhif y cerdyn adnabod gynnwy
 settlorIndividualIDCard.number.error.length = Mae’n rhaid i rif y cerdyn adnabod fod yn 30 o gymeriadau neu lai
 settlorIndividualIDCard.number.error.required = Nodwch rif cerdyn adnabod y setlwr
 settlorIndividualIDCard.title = Beth yw manylion cerdyn adnabod y setlwr?
+
+settlorIndividualIDCardPastTense.checkYourAnswersLabel = Beth yw manylion cerdyn ID diwethaf {0}?
+settlorIndividualIDCardPastTense.country = Gwlad cyhoeddi’r cerdyn adnabod
+settlorIndividualIDCardPastTense.country.error.length = Mae’n rhaid i wlad cerdyn adnabod y setlwr fod yn 100 o gymeriadau neu lai
+settlorIndividualIDCardPastTense.country.error.required = Nodwch wlad cyhoeddi cerdyn adnabod y setlwr
+settlorIndividualIDCardPastTense.error.country.required = Nodwch wlad cyhoeddi cerdyn adnabod y setlwr
+settlorIndividualIDCardPastTense.expiryDate.error.future = Mae’n rhaid i ddyddiad dod i ben y cerdyn adnabod fod ar ôl 31 Rhagfyr 1499 a chyn 01 Ionawr 2100
+settlorIndividualIDCardPastTense.expiryDate.error.invalid = Nodwch ddyddiad go iawn pan ddaw cerdyn adnabod y setlwr i ben
+settlorIndividualIDCardPastTense.expiryDate.error.past = Mae’n rhaid i ddyddiad dod i ben y cerdyn adnabod fod ar ôl 31 Rhagfyr 1499 a chyn 01 Ionawr 2100
+settlorIndividualIDCardPastTense.expiryDate.error.required = Mae’n rhaid i ddyddiad dod i ben y cerdyn adnabod gynnwys {0}
+settlorIndividualIDCardPastTense.expiryDate.error.required.all = Nodwch ddyddiad dod i ben y cerdyn adnabod
+settlorIndividualIDCardPastTense.expiryDate.error.required.two = Mae’n rhaid i ddyddiad dod i ben y cerdyn adnabod gynnwys {0} a {1}
+settlorIndividualIDCardPastTense.expiryDate.hint = Gall y dyddiad dod i ben fod yn y gorffennol. Er enghraifft, 31 3 1980.
+settlorIndividualIDCardPastTense.expiryDate.title = Dyddiad dod i ben
+settlorIndividualIDCardPastTense.heading = Beth yw manylion cerdyn ID diwethaf {0}?
+settlorIndividualIDCardPastTense.number = Rhif y cerdyn adnabod
+settlorIndividualIDCardPastTense.number.error.invalid = Gall rhif y cerdyn adnabod gynnwys llythrennau a rhifau yn unig
+settlorIndividualIDCardPastTense.number.error.length = Mae’n rhaid i rif y cerdyn adnabod fod yn 30 o gymeriadau neu lai
+settlorIndividualIDCardPastTense.number.error.required = Nodwch rif cerdyn adnabod y setlwr
+settlorIndividualIDCardPastTense.title = Beth yw manylion cerdyn ID diwethaf y setlwr?
 
 settlorIndividualIDCardYesNo.checkYourAnswersLabel = A ydych yn gwybod manylion cerdyn adnabod {0}?
 settlorIndividualIDCardYesNo.error.required = Dewiswch ‘Iawn’ os ydych yn gwybod manylion cerdyn adnabod y setlwr
@@ -432,6 +500,21 @@ settlorIndividualName.heading = Beth yw enw’r setlwr?
 settlorIndividualName.lastName = Enw olaf
 settlorIndividualName.middleName = Enwau canol (dewisol)
 settlorIndividualName.title = Beth yw enw’r setlwr?
+
+settlorIndividualNamePastTense.checkYourAnswersLabel = Beth oedd enw’r setlwr?
+settlorIndividualNamePastTense.error.firstname.invalid = Mae’n rhaid i enw cyntaf y setlwr gynnwys y llythrennau a i z yn unig
+settlorIndividualNamePastTense.error.firstname.length = Mae’n rhaid i enw cyntaf y setlwr fod yn 35 o gymeriadau neu lai
+settlorIndividualNamePastTense.error.firstname.required = Nodwch enw cyntaf y setlwr
+settlorIndividualNamePastTense.error.lastname.invalid = Mae’n rhaid i enw olaf y setlwr gynnwys y llythrennau a i z yn unig
+settlorIndividualNamePastTense.error.lastname.length = Mae’n rhaid i enw olaf y setlwr fod yn 35 o gymeriadau neu lai
+settlorIndividualNamePastTense.error.lastname.required = Nodwch enw olaf y setlwr
+settlorIndividualNamePastTense.error.middlename.invalid = Mae’n rhaid i enwau canol y setlwr gynnwys y llythrennau a i z yn unig
+settlorIndividualNamePastTense.error.middlename.length = Mae’n rhaid i enwau canol y setlwr fod yn 35 o gymeriadau neu lai
+settlorIndividualNamePastTense.firstName = Enw cyntaf
+settlorIndividualNamePastTense.heading = Beth oedd enw’r setlwr?
+settlorIndividualNamePastTense.lastName = Enw olaf
+settlorIndividualNamePastTense.middleName = Enwau canol (dewisol)
+settlorIndividualNamePastTense.title = Beth oedd enw’r setlwr?
 
 settlorIndividualNINO.checkYourAnswersLabel = Beth yw rhif Yswiriant Gwladol {0}?
 settlorIndividualNINO.error.invalidFormat = Nodwch rif Yswiriant Gwladol y setlwr yn y fformat cywir
@@ -474,6 +557,26 @@ settlorIndividualPassport.number.error.required = Nodwch rif pasbort y setlwr
 settlorIndividualPassport.number.hint = Er enghraifft, 502135326.
 settlorIndividualPassport.title = Beth yw manylion pasbort y setlwr?
 
+settlorIndividualPassportPastTense.checkYourAnswersLabel = Beth yw manylion pasbort diwethaf {0}?
+settlorIndividualPassportPastTense.country = Gwlad cyhoeddi’r pasbort
+settlorIndividualPassportPastTense.country.error.length = Mae’n rhaid i wlad pasbort y setlwr fod yn 100 o gymeriadau neu lai
+settlorIndividualPassportPastTense.country.error.required = Nodwch wlad cyhoeddi pasbort y setlwr
+settlorIndividualPassportPastTense.expiryDate.error.future = Mae’n rhaid i ddyddiad dod i ben y pasbort fod ar ôl 31 Rhagfyr 1499 a chyn 01 Ionawr 2100
+settlorIndividualPassportPastTense.expiryDate.error.invalid = Nodwch ddyddiad go iawn pan ddaw pasbort y setlwr i ben
+settlorIndividualPassportPastTense.expiryDate.error.past = Mae’n rhaid i ddyddiad dod i ben y pasbort fod ar ôl 31 Rhagfyr 1499 a chyn 01 Ionawr 2100
+settlorIndividualPassportPastTense.expiryDate.error.required = Mae’n rhaid i ddyddiad dod i ben y pasbort gynnwys {0}
+settlorIndividualPassportPastTense.expiryDate.error.required.all = Nodwch ddyddiad dod i ben y pasbort
+settlorIndividualPassportPastTense.expiryDate.error.required.two = Mae’n rhaid i ddyddiad dod i ben y pasbort gynnwys {0} a {1}
+settlorIndividualPassportPastTense.expiryDate.hint = Gall y dyddiad dod i ben fod yn y gorffennol. Er enghraifft, 31 3 1980.
+settlorIndividualPassportPastTense.expiryDate.title = Dyddiad dod i ben
+settlorIndividualPassportPastTense.heading = Beth yw manylion pasbort diwethaf {0}?
+settlorIndividualPassportPastTense.number = Rhif pasbort
+settlorIndividualPassportPastTense.number.error.invalid = Gall y rhif pasbort gynnwys llythrennau a rhifau yn unig
+settlorIndividualPassportPastTense.number.error.length = Mae’n rhaid i’r rhif pasbort fod yn 30 o gymeriadau neu lai
+settlorIndividualPassportPastTense.number.error.required = Nodwch rif pasbort y setlwr
+settlorIndividualPassportPastTense.number.hint = Er enghraifft, 502135326.
+settlorIndividualPassportPastTense.title = Beth yw manylion pasbort diwethaf y setlwr?
+
 settlorIndividualPassportYesNo.checkYourAnswersLabel = A ydych yn gwybod manylion pasbort {0}?
 settlorIndividualPassportYesNo.error.required = Dewiswch ‘Iawn’ os ydych yn gwybod manylion pasbort y setlwr
 settlorIndividualPassportYesNo.heading = A ydych yn gwybod manylion pasbort {0}?
@@ -484,10 +587,20 @@ settlorIndividualUkCountryOfNationalityYesNo.error.required = Dewiswch ‘Iawn�
 settlorIndividualUkCountryOfNationalityYesNo.heading = A oes gan {0} genedligrwydd y DU?
 settlorIndividualUkCountryOfNationalityYesNo.title = A oes gan y setlwr genedligrwydd y DU?
 
+settlorIndividualUkCountryOfNationalityYesNoPastTense.title = A oedd gan y setlwr genedligrwydd y DU?
+settlorIndividualUkCountryOfNationalityYesNoPastTense.heading = A oedd gan {0} genedligrwydd y DU?
+settlorIndividualUkCountryOfNationalityYesNoPastTense.checkYourAnswersLabel = A oedd gan {0} genedligrwydd y DU?
+settlorIndividualUkCountryOfNationalityYesNoPastTense.error.required = Dewiswch ‘Iawn’ os oedd gan y setlwr genedligrwydd y DU
+
 settlorIndividualUkCountryOfResidencyYesNo.checkYourAnswersLabel = A yw {0} yn breswylydd yn y DU?
 settlorIndividualUkCountryOfResidencyYesNo.error.required = Dewiswch ‘Iawn’ os yw’r setlwr yn breswylydd yn y DU
 settlorIndividualUkCountryOfResidencyYesNo.heading = A yw {0} yn breswylydd yn y DU?
 settlorIndividualUkCountryOfResidencyYesNo.title = A yw’r setlwr yn breswylydd yn y DU?
+
+settlorIndividualUkCountryOfResidencyYesNoPastTense.title = A oedd y setlwr yn breswylydd yn y DU?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.heading = A oedd {0} yn breswylydd yn y DU?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.checkYourAnswersLabel = A oedd {0} yn breswylydd yn y DU?
+settlorIndividualUkCountryOfResidencyYesNoPastTense.error.required = Dewiswch ‘Iawn’ os oedd y setlwr yn breswylydd yn y DU
 
 settlorInfo.bulletpoint1 = dyddiad y farwolaeth
 settlorInfo.bulletpoint10 = a oedd y busnes wedi bodoli am o leiaf 2 flynedd pan ychwanegwyd unrhyw ased at yr ymddiriedolaeth
@@ -581,11 +694,12 @@ settlorsUKAddress.checkYourAnswersLabel = Beth yw cyfeiriad hysbys diwethaf {0}?
 settlorsUKAddress.heading = Beth yw cyfeiriad hysbys diwethaf {0}?
 settlorsUKAddress.title = Beth yw cyfeiriad hysbys diwethaf y setlwr?
 
-setUpAfterSettlorDiedYesNo.checkYourAnswersLabel = A gafodd yr ymddiriedolaeth ei chreu ar ôl i’r setlwr farw?
-setUpAfterSettlorDiedYesNo.error.required = Dewiswch ‘Iawn’ os cafodd yr ymddiriedolaeth ei chreu ar ôl i’r setlwr farw
-setUpAfterSettlorDiedYesNo.heading = A gafodd yr ymddiriedolaeth ei chreu ar ôl i’r setlwr farw?
-setUpAfterSettlorDiedYesNo.hint = Gelwir hyn hefyd yn ymddiriedolaeth ewyllys.
-setUpAfterSettlorDiedYesNo.title = A gafodd yr ymddiriedolaeth ei chreu ar ôl i’r setlwr farw?
+setUpByLivingSettlorYesNo.title = A gafodd yr ymddiriedolaeth ei chreu gan setlwr byw?
+setUpByLivingSettlorYesNo.heading = A gafodd yr ymddiriedolaeth ei chreu gan setlwr byw?
+setUpByLivingSettlorYesNo.checkYourAnswersLabel = A gafodd yr ymddiriedolaeth ei chreu gan setlwr byw?
+setUpByLivingSettlorYesNo.error.required = Dewiswch ‘Iawn’ os cafodd yr ymddiriedolaeth ei chreu gan setlwr byw
+setUpByLivingSettlorYesNo.yes = Iawn, cafodd yr ymddiriedolaeth ei chreu gan setlwr byw
+setUpByLivingSettlorYesNo.no = Na, ‘ymddiriedolaeth ewyllys’ yw hi neu ymddiriedolaeth a gafodd ei chreu ar ôl i’r setlwr farw
 
 setUpInAdditionToWillTrustYesNo.checkYourAnswersLabel = A yw hyn yn ychwanegol at ymddiriedolaeth ewyllys?
 setUpInAdditionToWillTrustYesNo.error.required = Dewiswch ‘Iawn’ os yw’r ymddiriedolaeth yn ychwanegol at ymddiriedolaeth ewyllys

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -25,7 +25,8 @@ object AppDependencies {
     "wolfendale"                  %% "scalacheck-gen-regexp"    % "0.1.2",
     "org.scalacheck"              %% "scalacheck"               % "1.17.0",
     "com.github.tomakehurst"      % "wiremock-standalone"       % "2.27.2",
-    "com.vladsch.flexmark"        % "flexmark-all"              % "0.62.2"
+    "com.vladsch.flexmark"        % "flexmark-all"              % "0.62.2",
+    "uk.gov.hmrc"                 %% "bootstrap-test-play-28"   % bootstrapVersion
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/test/controllers/deceased_settlor/DeceasedSettlorAnswerControllerSpec.scala
+++ b/test/controllers/deceased_settlor/DeceasedSettlorAnswerControllerSpec.scala
@@ -63,7 +63,7 @@ class DeceasedSettlorAnswerControllerSpec extends SpecBase with BeforeAndAfterEa
 
       val fakeAnswerSection = AnswerSection()
 
-      when(mockPrintHelper.checkDetailsSection(any(), any(), any(), any())(any()))
+      when(mockPrintHelper.checkDetailsSection(any(), any(), any(), any(), any())(any()))
         .thenReturn(fakeAnswerSection)
 
       val answers: UserAnswers = emptyUserAnswers

--- a/test/controllers/living_settlor/business/SettlorBusinessAnswerControllerSpec.scala
+++ b/test/controllers/living_settlor/business/SettlorBusinessAnswerControllerSpec.scala
@@ -55,7 +55,7 @@ class SettlorBusinessAnswerControllerSpec extends SpecBase {
 
       val fakeAnswerSection = AnswerSection()
 
-      when(mockPrintHelper.checkDetailsSection(any(), any(), any(), any())(any()))
+      when(mockPrintHelper.checkDetailsSection(any(), any(), any(), any(), any())(any()))
         .thenReturn(fakeAnswerSection)
 
       val application: Application = applicationBuilder(userAnswers = Some(baseAnswers))

--- a/test/controllers/living_settlor/individual/SettlorAliveYesNoControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorAliveYesNoControllerSpec.scala
@@ -14,58 +14,60 @@
  * limitations under the License.
  */
 
-package controllers.trust_type
+package controllers.living_settlor.individual
 
 import base.SpecBase
-import controllers.routes._
+import controllers.routes.SessionExpiredController
 import forms.YesNoFormProvider
-import pages.trust_type.SetUpAfterSettlorDiedYesNoPage
+import pages.living_settlor.individual.SettlorAliveYesNoPage
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import views.html.trust_type.SetUpAfterSettlorDiedView
+import views.html.living_settlor.individual.SettlorAliveYesNoView
 
-class SetUpAfterSettlorDiedControllerSpec extends SpecBase {
+class SettlorAliveYesNoControllerSpec extends SpecBase {
 
-  val form = new YesNoFormProvider().withPrefix("setUpAfterSettlorDiedYesNo")
+  private lazy val settlorAliveYesNoGetRoute = controllers.living_settlor.individual.routes.SettlorAliveYesNoController.onPageLoad(index, draftId).url
+  private lazy val settlorAliveYesNoPostRoute = controllers.living_settlor.individual.routes.SettlorAliveYesNoController.onSubmit(index, draftId).url
+  private val index = 0
+  private val formProvider = new YesNoFormProvider()
+  private val form = formProvider.withPrefix("settlorAliveYesNo")
 
-  lazy val setUpAfterSettlorDiedRoute = routes.SetUpAfterSettlorDiedController.onPageLoad(fakeDraftId).url
-
-  "SetUpAfterSettlorDied Controller" must {
+  "SettlorAliveYesNo Controller" must {
 
     "return OK and the correct view for a GET" in {
 
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
-      val request = FakeRequest(GET, setUpAfterSettlorDiedRoute)
+      val request = FakeRequest(GET, settlorAliveYesNoGetRoute)
 
       val result = route(application, request).value
 
-      val view = application.injector.instanceOf[SetUpAfterSettlorDiedView]
+      val view = application.injector.instanceOf[SettlorAliveYesNoView]
 
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form,fakeDraftId, isTaxable = true)(request, messages).toString
+        view(form, draftId, index)(request, messages).toString()
 
       application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, true).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), false).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, setUpAfterSettlorDiedRoute)
-
-      val view = application.injector.instanceOf[SetUpAfterSettlorDiedView]
+      val request = FakeRequest(GET, settlorAliveYesNoGetRoute)
 
       val result = route(application, request).value
+
+      val view = application.injector.instanceOf[SettlorAliveYesNoView]
 
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(true), fakeDraftId, isTaxable = true)(request, messages).toString
+        view(form.fill(false), draftId, index)(request, messages).toString()
 
       application.stop()
     }
@@ -76,7 +78,7 @@ class SetUpAfterSettlorDiedControllerSpec extends SpecBase {
         applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       val request =
-        FakeRequest(POST, setUpAfterSettlorDiedRoute)
+        FakeRequest(POST, settlorAliveYesNoPostRoute)
           .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(application, request).value
@@ -90,22 +92,40 @@ class SetUpAfterSettlorDiedControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
       val request =
-        FakeRequest(POST, setUpAfterSettlorDiedRoute)
+        FakeRequest(POST, settlorAliveYesNoPostRoute)
           .withFormUrlEncodedBody(("value", ""))
 
       val boundForm = form.bind(Map("value" -> ""))
 
-      val view = application.injector.instanceOf[SetUpAfterSettlorDiedView]
+      val view = application.injector.instanceOf[SettlorAliveYesNoView]
 
       val result = route(application, request).value
 
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, fakeDraftId, isTaxable = true)(request, messages).toString
+        view(boundForm, draftId, index)(request, messages).toString
+
+      application.stop()
+    }
+
+    "return an Internal Server Error when the try fails" in {
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      val request =
+        FakeRequest(POST, routes.SettlorAliveYesNoController.onSubmit(index + 2, fakeDraftId).url)
+          .withFormUrlEncodedBody(("value", "true"))
+
+      val result = route(application, request).value
+
+      status(result) mustEqual INTERNAL_SERVER_ERROR
 
       application.stop()
     }
@@ -114,7 +134,7 @@ class SetUpAfterSettlorDiedControllerSpec extends SpecBase {
 
       val application = applicationBuilder(userAnswers = None).build()
 
-      val request = FakeRequest(GET, setUpAfterSettlorDiedRoute)
+      val request = FakeRequest(GET, settlorAliveYesNoGetRoute)
 
       val result = route(application, request).value
 
@@ -129,9 +149,7 @@ class SetUpAfterSettlorDiedControllerSpec extends SpecBase {
 
       val application = applicationBuilder(userAnswers = None).build()
 
-      val request =
-        FakeRequest(POST, setUpAfterSettlorDiedRoute)
-          .withFormUrlEncodedBody(("value", "true"))
+      val request = FakeRequest(GET, settlorAliveYesNoPostRoute)
 
       val result = route(application, request).value
 
@@ -142,4 +160,5 @@ class SetUpAfterSettlorDiedControllerSpec extends SpecBase {
       application.stop()
     }
   }
+
 }

--- a/test/controllers/living_settlor/individual/SettlorIndividualAddressInternationalControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorIndividualAddressInternationalControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.routes._
 import forms.InternationalAddressFormProvider
 import models.UserAnswers
 import models.pages.{FullName, InternationalAddress}
-import pages.living_settlor.individual.{SettlorAddressInternationalPage, SettlorIndividualNINOPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAddressInternationalPage, SettlorAliveYesNoPage, SettlorIndividualNINOPage, SettlorIndividualNamePage}
 import play.api.Application
 import play.api.data.Form
 import play.api.mvc.{Call, Result}
@@ -35,14 +35,14 @@ import scala.concurrent.Future
 
 class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
 
-  def onwardRoute = Call("GET", "/foo")
+  private def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new InternationalAddressFormProvider()
-  val form: Form[InternationalAddress] = formProvider()
-  val index = 0
-  val name = FullName("First", Some("Middle"), "Last")
+  private val formProvider = new InternationalAddressFormProvider()
+  private val form: Form[InternationalAddress] = formProvider()
+  private val index = 0
+  private val name = FullName("First", Some("Middle"), "Last")
 
-  lazy val settlorIndividualAddressInternationalRoute: String = routes.SettlorIndividualAddressInternationalController.onPageLoad(index, fakeDraftId).url
+  private lazy val settlorIndividualAddressInternationalRoute: String = routes.SettlorIndividualAddressInternationalController.onPageLoad(index, fakeDraftId).url
 
 
   "SettlorIndividualAddressInternational Controller" must {
@@ -64,14 +64,15 @@ class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, countryOptions, index, fakeDraftId, name)(request, messages).toString
+        view(form, countryOptions, index, fakeDraftId, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressInternationalPage(index), InternationalAddress("line 1", "line 2", Some("line 3"), "country")).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -87,14 +88,16 @@ class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(InternationalAddress("line 1", "line 2", Some("line 3"), "country")), countryOptions, index, fakeDraftId, name)(request, messages).toString
+        view(form.fill(InternationalAddress("line 1", "line 2", Some("line 3"), "country")), countryOptions, index,
+          fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressInternationalPage(index), InternationalAddress("line 1", "line 2", Some("line 3"), "country")).success.value
 
       val application =
@@ -115,7 +118,7 @@ class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
 
     "redirect to Settlors Name page when Settlors name is not answered" in {
 
-      val userAnswers = emptyUserAnswers
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
         .set(SettlorIndividualNINOPage(index), "CC123456A").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -133,7 +136,8 @@ class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -152,7 +156,7 @@ class SettlorIndividualAddressInternationalControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, countryOptions, index, fakeDraftId, name)(request, messages).toString
+        view(boundForm, countryOptions, index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/SettlorIndividualAddressUKControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorIndividualAddressUKControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.routes._
 import forms.UKAddressFormProvider
 import models.pages.{FullName, UKAddress}
-import pages.living_settlor.individual.{SettlorAddressUKPage, SettlorIndividualNINOPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAddressUKPage, SettlorAliveYesNoPage, SettlorIndividualNINOPage, SettlorIndividualNamePage}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -28,14 +28,14 @@ import views.html.living_settlor.individual.SettlorIndividualAddressUKView
 
 class SettlorIndividualAddressUKControllerSpec extends SpecBase {
 
-  def onwardRoute = Call("GET", "/foo")
+  private def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new UKAddressFormProvider()
-  val form = formProvider()
-  val index = 0
-  val name = FullName("First", Some("Middle"), "Last")
+  private val formProvider = new UKAddressFormProvider()
+  private val form = formProvider()
+  private val index = 0
+  private val name = FullName("First", Some("Middle"), "Last")
 
-  lazy val settlorIndividualAddressUKRoute: String = routes.SettlorIndividualAddressUKController.onPageLoad(index, fakeDraftId).url
+  private lazy val settlorIndividualAddressUKRoute: String = routes.SettlorIndividualAddressUKController.onPageLoad(index, fakeDraftId).url
 
   "SettlorIndividualAddressUK Controller" must {
 
@@ -54,14 +54,15 @@ class SettlorIndividualAddressUKControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, fakeDraftId, index, name)(request, messages).toString
+        view(form, fakeDraftId, index, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressUKPage(index), UKAddress("line 1", "line 2", Some("line 3"), Some("line 4"), "line 5")).success.value
 
       val application = applicationBuilder(Some(userAnswers)).build()
@@ -75,14 +76,16 @@ class SettlorIndividualAddressUKControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(UKAddress("line 1", "line 2", Some("line 3"), Some("line 4"), "line 5")), fakeDraftId, index, name)(request, messages).toString
+        view(form.fill(UKAddress("line 1", "line 2", Some("line 3"), Some("line 4"), "line 5")), fakeDraftId, index,
+          name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressUKPage(index), UKAddress("line 1", "line 2", Some("line 3"), Some("line 4"), "line 5")).success.value
 
       val application =
@@ -103,7 +106,7 @@ class SettlorIndividualAddressUKControllerSpec extends SpecBase {
 
     "redirect to Settlors Name page when Settlors name is not answered" in {
 
-      val userAnswers = emptyUserAnswers
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
         .set(SettlorIndividualNINOPage(index), "CC123456A").success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -121,8 +124,8 @@ class SettlorIndividualAddressUKControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index),
-        name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -139,7 +142,7 @@ class SettlorIndividualAddressUKControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, fakeDraftId, index, name)(request, messages).toString
+        view(boundForm, fakeDraftId, index, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/SettlorIndividualAddressUKYesNoControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorIndividualAddressUKYesNoControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.routes._
 import forms.YesNoFormProvider
 import models.pages.FullName
-import pages.living_settlor.individual.{SettlorAddressUKYesNoPage, SettlorIndividualDateOfBirthYesNoPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAddressUKYesNoPage, SettlorAliveYesNoPage, SettlorIndividualDateOfBirthYesNoPage, SettlorIndividualNamePage}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -28,20 +28,22 @@ import views.html.living_settlor.individual.SettlorIndividualAddressUKYesNoView
 
 class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
 
-  def onwardRoute = Call("GET", "/foo")
+  private def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new YesNoFormProvider()
-  val form = formProvider.withPrefix("settlorIndividualAddressUKYesNo")
-  val index = 0
-  val name = FullName("First", Some("Middle"), "Last")
+  private val formProvider = new YesNoFormProvider()
+  private val form = formProvider.withPrefix("settlorIndividualAddressUKYesNo")
+  private val index = 0
+  private val name = FullName("First", Some("Middle"), "Last")
 
-  lazy val settlorIndividualAddressUKYesNoRoute = routes.SettlorIndividualAddressUKYesNoController.onPageLoad(index, fakeDraftId).url
+  private lazy val settlorIndividualAddressUKYesNoRoute = routes.SettlorIndividualAddressUKYesNoController.onPageLoad(index, fakeDraftId).url
 
   "SettlorIndividualAddressUKYesNo Controller" must {
 
     "return OK and the correct view for a GET" in {
+      val formContentInPastTense = formProvider.withPrefix("settlorIndividualAddressUKYesNoPastTense")
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers
+        .set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -54,14 +56,15 @@ class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, fakeDraftId, index, name)(request, messages).toString
+        view(formContentInPastTense, fakeDraftId, index, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressUKYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -75,14 +78,15 @@ class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(true), fakeDraftId, index, name)(request, messages).toString
+        view(form.fill(true), fakeDraftId, index, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -101,7 +105,8 @@ class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressUKYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -119,7 +124,7 @@ class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, fakeDraftId, index, name)(request, messages).toString
+        view(boundForm, fakeDraftId, index, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
@@ -127,6 +132,7 @@ class SettlorIndividualAddressUKYesNoControllerSpec extends SpecBase {
     "redirect to Settlors Name page when Settlors name is not answered" in {
 
       val userAnswers = emptyUserAnswers
+        .set(SettlorAliveYesNoPage(index), true).success.value
         .set(SettlorIndividualDateOfBirthYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()

--- a/test/controllers/living_settlor/individual/SettlorIndividualAddressYesNoControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorIndividualAddressYesNoControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.routes._
 import forms.YesNoFormProvider
 import models.pages.FullName
-import pages.living_settlor.individual.{SettlorAddressYesNoPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAddressYesNoPage, SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import views.html.living_settlor.individual.SettlorIndividualAddressYesNoView
@@ -37,6 +37,7 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
   "SettlorIndividualAddressYesNo Controller" must {
 
     "return OK and the correct view for a GET" in {
+      val formContentInPastTense = formProvider.withPrefix("settlorIndividualAddressYesNoPastTense")
 
       val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
 
@@ -51,14 +52,15 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, fakeDraftId, index, name)(request, messages).toString
+        view(formContentInPastTense, fakeDraftId, index, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -72,14 +74,15 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(true), fakeDraftId, index, name)(request, messages).toString
+        view(form.fill(true), fakeDraftId, index, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorAddressYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -99,7 +102,7 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
 
     "redirect to Settlors Name page when Settlors name is not answered" in {
 
-      val userAnswers = emptyUserAnswers
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
         .set(SettlorAddressYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -117,8 +120,8 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index),
-        name).success.value
+      val userAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+        .set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -135,7 +138,7 @@ class SettlorIndividualAddressYesNoControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, fakeDraftId, index, name)(request, messages).toString
+        view(boundForm, fakeDraftId, index, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/SettlorIndividualDateOfBirthControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorIndividualDateOfBirthControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.routes._
 import forms.DateOfBirthFormProvider
 import models.pages.FullName
-import pages.living_settlor.individual.{SettlorIndividualDateOfBirthPage, SettlorIndividualDateOfBirthYesNoPage, SettlorIndividualNamePage}
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualDateOfBirthPage, SettlorIndividualDateOfBirthYesNoPage, SettlorIndividualNamePage}
 import play.api.data.Form
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -42,31 +42,37 @@ class SettlorIndividualDateOfBirthControllerSpec extends SpecBase {
 
   "SettlorIndividualDateOfBirth Controller" must {
 
-    "return OK and the correct view for a GET" in {
+    Seq(true, false)
+      .foreach(setUpBeforeSettlorDied =>
+        s"return OK and the correct view for a GET when the userAnswers SetUpBeforeSettlorDied is set to $setUpBeforeSettlorDied" in {
 
-      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+          val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+            .set(SettlorAliveYesNoPage(index), setUpBeforeSettlorDied)
+            .success.value
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+          val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, settlorIndividualDateOfBirthRoute)
+          val request = FakeRequest(GET, settlorIndividualDateOfBirthRoute)
 
-      val result = route(application, request).value
+          val result = route(application, request).value
 
-      val view = application.injector.instanceOf[SettlorIndividualDateOfBirthView]
+          val view = application.injector.instanceOf[SettlorIndividualDateOfBirthView]
 
-      status(result) mustEqual OK
+          status(result) mustEqual OK
 
-      contentAsString(result) mustEqual
-        view(form, fakeDraftId, index, name)(request, messages).toString
+          contentAsString(result) mustEqual
+            view(form, fakeDraftId, index, name, setUpBeforeSettlorDied = setUpBeforeSettlorDied)(request, messages).toString
 
-      application.stop()
-    }
+          application.stop()
+        }
+      )
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
       val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorIndividualDateOfBirthYesNoPage(index), true).success.value
         .set(SettlorIndividualDateOfBirthPage(index), validAnswer).success.value
+        .set(SettlorAliveYesNoPage(index), false).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -79,7 +85,7 @@ class SettlorIndividualDateOfBirthControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(validAnswer), fakeDraftId, index, name)(request, messages).toString
+        view(form.fill(validAnswer), fakeDraftId, index, name, setUpBeforeSettlorDied = false)(request, messages).toString
 
       application.stop()
     }
@@ -111,6 +117,7 @@ class SettlorIndividualDateOfBirthControllerSpec extends SpecBase {
     "redirect to Settlors Name page when Settlors name is not answered" in {
 
       val userAnswers = emptyUserAnswers.set(SettlorIndividualDateOfBirthYesNoPage(index), true).success.value
+        .set(SettlorAliveYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -128,7 +135,6 @@ class SettlorIndividualDateOfBirthControllerSpec extends SpecBase {
     "return a Bad Request and errors when invalid data is submitted" in {
 
       val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
-        .set(SettlorIndividualDateOfBirthYesNoPage(index), true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -145,7 +151,7 @@ class SettlorIndividualDateOfBirthControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, fakeDraftId, index, name)(request, messages).toString
+        view(boundForm, fakeDraftId, index, name, setUpBeforeSettlorDied = false)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/SettlorIndividualNameControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/SettlorIndividualNameControllerSpec.scala
@@ -19,8 +19,9 @@ package controllers.living_settlor.individual
 import base.SpecBase
 import controllers.routes._
 import forms.living_settlor.SettlorIndividualNameFormProvider
+import models.UserAnswers
 import models.pages.FullName
-import pages.living_settlor.individual.SettlorIndividualNamePage
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import play.api.mvc.Call
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -39,23 +40,29 @@ class SettlorIndividualNameControllerSpec extends SpecBase {
 
   "SettlorIndividualName Controller" must {
 
-    "return OK and the correct view for a GET" in {
+    Seq(true, false)
+      .foreach(setUpBeforeSettlorDied =>
+        s"return OK and the correct view for a GET when the userAnswers SetUpBeforeSettlorDied is set to $setUpBeforeSettlorDied" in {
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+          val userAnswers: UserAnswers = emptyUserAnswers
+            .set(SettlorAliveYesNoPage(index), setUpBeforeSettlorDied).success.value
 
-      val request = FakeRequest(GET, settlorIndividualNameRoute)
+          val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val view = application.injector.instanceOf[SettlorIndividualNameView]
+          val request = FakeRequest(GET, settlorIndividualNameRoute)
 
-      val result = route(application, request).value
+          val view = application.injector.instanceOf[SettlorIndividualNameView]
 
-      status(result) mustEqual OK
+          val result = route(application, request).value
 
-      contentAsString(result) mustEqual
-        view(form, fakeDraftId, index)(request, messages).toString
+          status(result) mustEqual OK
 
-      application.stop()
-    }
+          contentAsString(result) mustEqual
+            view(form, fakeDraftId, index, setUpBeforeSettlorDied = setUpBeforeSettlorDied)(request, messages).toString
+
+          application.stop()
+        }
+      )
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
@@ -73,7 +80,7 @@ class SettlorIndividualNameControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(FullName("first name", Some("middle name"), "last name")), fakeDraftId, index)(request, messages).toString
+        view(form.fill(FullName("first name", Some("middle name"), "last name")), fakeDraftId, index, setUpBeforeSettlorDied = false)(request, messages).toString
 
       application.stop()
     }
@@ -129,7 +136,7 @@ class SettlorIndividualNameControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, fakeDraftId, index)(request, messages).toString
+        view(boundForm, fakeDraftId, index, setUpBeforeSettlorDied = false)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/mld5/CountryOfNationalityControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/mld5/CountryOfNationalityControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.routes._
 import forms.CountryFormProvider
 import models.UserAnswers
 import models.pages.FullName
-import pages.living_settlor.individual.SettlorIndividualNamePage
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import pages.living_settlor.individual.mld5.CountryOfNationalityPage
 import play.api.data.Form
 import play.api.test.FakeRequest
@@ -45,13 +45,16 @@ class CountryOfNationalityControllerSpec extends SpecBase {
   private val validAnswer: String = "France"
   private val validFormAnswer: String = "FR"
 
-  private val baseAnswers: UserAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+  private val baseAnswers: UserAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+    .set(SettlorIndividualNamePage(index), name).success.value
 
   "CountryOfNationality Controller" must {
 
     "return OK and the correct view for a GET" in {
 
-      val userAnswers = baseAnswers
+      val formContentInPastTense: Form[String] = formProvider.withPrefix("settlorIndividualCountryOfNationalityPastTense")
+
+      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -64,7 +67,7 @@ class CountryOfNationalityControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, index, fakeDraftId, countryOptions, name)(request, messages).toString
+        view(formContentInPastTense, index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
@@ -85,7 +88,7 @@ class CountryOfNationalityControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(validAnswer), index, fakeDraftId, countryOptions, name)(request, messages).toString
+        view(form.fill(validAnswer), index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
@@ -126,7 +129,7 @@ class CountryOfNationalityControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, index, fakeDraftId, countryOptions, name)(request, messages).toString
+        view(boundForm, index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/mld5/CountryOfResidencyControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/mld5/CountryOfResidencyControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.routes._
 import forms.CountryFormProvider
 import models.UserAnswers
 import models.pages.FullName
-import pages.living_settlor.individual.SettlorIndividualNamePage
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import pages.living_settlor.individual.mld5.CountryOfResidencyPage
 import play.api.data.Form
 import play.api.test.FakeRequest
@@ -45,13 +45,16 @@ class CountryOfResidencyControllerSpec extends SpecBase {
   private val validAnswer: String = "France"
   private val validFormAnswer: String = "FR"
 
-  private val baseAnswers: UserAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+  private val baseAnswers: UserAnswers = emptyUserAnswers
+    .set(SettlorAliveYesNoPage(index), true).success.value
+    .set(SettlorIndividualNamePage(index), name).success.value
 
   "CountryOfResidency Controller" must {
 
     "return OK and the correct view for a GET" in {
+      val formContentInPastTense: Form[String] = formProvider.withPrefix("settlorIndividualCountryOfResidencyPastTense")
 
-      val userAnswers = baseAnswers
+      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -64,7 +67,7 @@ class CountryOfResidencyControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, index, fakeDraftId, countryOptions, name)(request, messages).toString
+        view(formContentInPastTense, index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
@@ -85,7 +88,7 @@ class CountryOfResidencyControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(validAnswer), index, fakeDraftId, countryOptions, name)(request, messages).toString
+        view(form.fill(validAnswer), index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
@@ -126,7 +129,7 @@ class CountryOfResidencyControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, index, fakeDraftId, countryOptions, name)(request, messages).toString
+        view(boundForm, index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/mld5/CountryOfResidencyYesNoControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/mld5/CountryOfResidencyYesNoControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.routes._
 import forms.YesNoFormProvider
 import models.UserAnswers
 import models.pages.FullName
-import pages.living_settlor.individual.SettlorIndividualNamePage
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import pages.living_settlor.individual.mld5.CountryOfResidencyYesNoPage
 import play.api.data.Form
 import play.api.test.FakeRequest
@@ -40,13 +40,17 @@ class CountryOfResidencyYesNoControllerSpec extends SpecBase {
 
   private val validAnswer: Boolean = true
 
-  private val baseAnswers: UserAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+  private val baseAnswers: UserAnswers = emptyUserAnswers
+    .set(SettlorAliveYesNoPage(index), true).success.value
+    .set(SettlorIndividualNamePage(index), name).success.value
 
   "CountryOfResidencyYesNo Controller" must {
 
     "return OK and the correct view for a GET" in {
 
-      val userAnswers = baseAnswers
+      val formContentInPastTense: Form[Boolean] = formProvider.withPrefix("settlorIndividualCountryOfResidencyYesNoPastTense")
+
+      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -59,7 +63,7 @@ class CountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, index, fakeDraftId, name)(request, messages).toString
+        view(formContentInPastTense, index, fakeDraftId, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
@@ -80,7 +84,7 @@ class CountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(validAnswer), index, fakeDraftId, name)(request, messages).toString
+        view(form.fill(validAnswer), index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
@@ -121,7 +125,7 @@ class CountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, index, fakeDraftId, name)(request, messages).toString
+        view(boundForm, index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/mld5/UkCountryOfNationalityYesNoControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/mld5/UkCountryOfNationalityYesNoControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.routes._
 import forms.YesNoFormProvider
 import models.UserAnswers
 import models.pages.FullName
-import pages.living_settlor.individual.SettlorIndividualNamePage
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import pages.living_settlor.individual.mld5.UkCountryOfNationalityYesNoPage
 import play.api.data.Form
 import play.api.test.FakeRequest
@@ -40,13 +40,16 @@ class UkCountryOfNationalityYesNoControllerSpec extends SpecBase {
 
   private val validAnswer: Boolean = true
 
-  private val baseAnswers: UserAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+  private val baseAnswers: UserAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+    .set(SettlorIndividualNamePage(index), name).success.value
 
   "UkCountryOfNationalityYesNo Controller" must {
 
     "return OK and the correct view for a GET" in {
 
-      val userAnswers = baseAnswers
+      val formContentInPastTense = formProvider.withPrefix("settlorIndividualUkCountryOfNationalityYesNoPastTense")
+
+      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -59,7 +62,7 @@ class UkCountryOfNationalityYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, index, fakeDraftId, name)(request, messages).toString
+        view(formContentInPastTense, index, fakeDraftId, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
@@ -80,7 +83,7 @@ class UkCountryOfNationalityYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(true), index, fakeDraftId, name)(request, messages).toString
+        view(form.fill(true), index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
@@ -121,7 +124,7 @@ class UkCountryOfNationalityYesNoControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, index, fakeDraftId, name)(request, messages).toString
+        view(boundForm, index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/living_settlor/individual/mld5/UkCountryOfResidencyYesNoControllerSpec.scala
+++ b/test/controllers/living_settlor/individual/mld5/UkCountryOfResidencyYesNoControllerSpec.scala
@@ -22,7 +22,7 @@ import controllers.routes._
 import forms.YesNoFormProvider
 import models.UserAnswers
 import models.pages.FullName
-import pages.living_settlor.individual.SettlorIndividualNamePage
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import pages.living_settlor.individual.mld5.UkCountryOfResidencyYesNoPage
 import play.api.data.Form
 import play.api.test.FakeRequest
@@ -40,13 +40,17 @@ class UkCountryOfResidencyYesNoControllerSpec extends SpecBase {
 
   private val validAnswer: Boolean = true
 
-  private val baseAnswers: UserAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
+  private val baseAnswers: UserAnswers = emptyUserAnswers
+    .set(SettlorAliveYesNoPage(index), true).success.value
+    .set(SettlorIndividualNamePage(index), name).success.value
 
   "UkCountryOfResidencyYesNo Controller" must {
 
     "return OK and the correct view for a GET" in {
 
-      val userAnswers = baseAnswers
+      val formContentInPastTense: Form[Boolean] = formProvider.withPrefix("settlorIndividualUkCountryOfResidencyYesNoPastTense")
+
+      val userAnswers = emptyUserAnswers.set(SettlorIndividualNamePage(index), name).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -59,7 +63,7 @@ class UkCountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, index, fakeDraftId, name)(request, messages).toString
+        view(formContentInPastTense, index, fakeDraftId, name, settlorAliveAtRegistration = false)(request, messages).toString
 
       application.stop()
     }
@@ -80,7 +84,7 @@ class UkCountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(validAnswer), index, fakeDraftId, name)(request, messages).toString
+        view(form.fill(validAnswer), index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }
@@ -121,7 +125,7 @@ class UkCountryOfResidencyYesNoControllerSpec extends SpecBase {
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, index, fakeDraftId, name)(request, messages).toString
+        view(boundForm, index, fakeDraftId, name, settlorAliveAtRegistration = true)(request, messages).toString
 
       application.stop()
     }

--- a/test/controllers/trust_type/AdditionToWillTrustYesNoControllerSpec.scala
+++ b/test/controllers/trust_type/AdditionToWillTrustYesNoControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.trust_type
 import base.SpecBase
 import controllers.routes._
 import forms.YesNoFormProvider
-import pages.trust_type.{SetUpAfterSettlorDiedYesNoPage, SetUpInAdditionToWillTrustYesNoPage}
+import pages.trust_type.{SetUpByLivingSettlorYesNoPage, SetUpInAdditionToWillTrustYesNoPage}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import views.html.trust_type.AdditionToWillTrustYesNoView
@@ -35,7 +35,7 @@ class AdditionToWillTrustYesNoControllerSpec extends SpecBase {
 
     "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -56,7 +56,7 @@ class AdditionToWillTrustYesNoControllerSpec extends SpecBase {
     "populate the view correctly on a GET when the question has previously been answered" in {
 
       val userAnswers = emptyUserAnswers
-        .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+        .set(SetUpByLivingSettlorYesNoPage, false).success.value
         .set(SetUpInAdditionToWillTrustYesNoPage, true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -77,7 +77,7 @@ class AdditionToWillTrustYesNoControllerSpec extends SpecBase {
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
       val application =
         applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -97,7 +97,7 @@ class AdditionToWillTrustYesNoControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/trust_type/HoldoverReliefYesNoControllerSpec.scala
+++ b/test/controllers/trust_type/HoldoverReliefYesNoControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.trust_type
 import base.SpecBase
 import controllers.routes._
 import forms.YesNoFormProvider
-import pages.trust_type.{HoldoverReliefYesNoPage, SetUpAfterSettlorDiedYesNoPage}
+import pages.trust_type.{HoldoverReliefYesNoPage, SetUpByLivingSettlorYesNoPage}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import views.html.trust_type.HoldoverReliefYesNoView
@@ -35,7 +35,7 @@ class HoldoverReliefYesNoControllerSpec extends SpecBase {
 
     "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -55,7 +55,7 @@ class HoldoverReliefYesNoControllerSpec extends SpecBase {
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value.set(HoldoverReliefYesNoPage, true).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value.set(HoldoverReliefYesNoPage, true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -75,7 +75,7 @@ class HoldoverReliefYesNoControllerSpec extends SpecBase {
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
       val application =
         applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -95,7 +95,7 @@ class HoldoverReliefYesNoControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/trust_type/KindOfTrustControllerSpec.scala
+++ b/test/controllers/trust_type/KindOfTrustControllerSpec.scala
@@ -20,7 +20,7 @@ import base.SpecBase
 import controllers.routes._
 import forms.KindOfTrustFormProvider
 import models.pages.KindOfTrust
-import pages.trust_type.{KindOfTrustPage, SetUpAfterSettlorDiedYesNoPage}
+import pages.trust_type.{KindOfTrustPage, SetUpByLivingSettlorYesNoPage}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import views.html.trust_type.KindOfTrustView
@@ -38,7 +38,7 @@ class KindOfTrustControllerSpec extends SpecBase {
 
     "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
@@ -58,7 +58,7 @@ class KindOfTrustControllerSpec extends SpecBase {
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
         .set(KindOfTrustPage, KindOfTrust.values.head).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -79,7 +79,7 @@ class KindOfTrustControllerSpec extends SpecBase {
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
       val application =
         applicationBuilder(userAnswers = Some(userAnswers)).build()
@@ -99,7 +99,7 @@ class KindOfTrustControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 

--- a/test/controllers/trust_type/SetUpByLivingSettlorControllerSpec.scala
+++ b/test/controllers/trust_type/SetUpByLivingSettlorControllerSpec.scala
@@ -18,75 +18,66 @@ package controllers.trust_type
 
 import base.SpecBase
 import controllers.routes._
-import forms.DeedOfVariationFormProvider
-import models.pages.{DeedOfVariation, KindOfTrust}
-import pages.trust_type.{HowDeedOfVariationCreatedPage, SetUpByLivingSettlorYesNoPage}
+import forms.YesNoFormProvider
+import pages.trust_type.SetUpByLivingSettlorYesNoPage
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import views.html.trust_type.HowDeedOfVariationCreatedView
+import views.html.trust_type.SetUpByLivingSettlorView
 
-class HowDeedOfVariationCreatedControllerSpec extends SpecBase {
+class SetUpByLivingSettlorControllerSpec extends SpecBase {
 
-  val index = 0
+  val form = new YesNoFormProvider().withPrefix("setUpByLivingSettlorYesNo")
 
-  lazy val deedOfVariationRoute = routes.HowDeedOfVariationCreatedController.onPageLoad(fakeDraftId).url
+  lazy val setUpByLivingSettlorRoute = routes.SetUpByLivingSettlorController.onPageLoad(fakeDraftId).url
 
-  val formProvider = new DeedOfVariationFormProvider()
-  val form = formProvider()
-
-  "HowDeedOfVariationCreated Controller" must {
+  "SetUpByLivingSettlor Controller" must {
 
     "return OK and the correct view for a GET" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
-
-      val request = FakeRequest(GET, deedOfVariationRoute)
+      val request = FakeRequest(GET, setUpByLivingSettlorRoute)
 
       val result = route(application, request).value
 
-      val view = application.injector.instanceOf[HowDeedOfVariationCreatedView]
+      val view = application.injector.instanceOf[SetUpByLivingSettlorView]
 
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form, fakeDraftId)(request, messages).toString
+        view(form,fakeDraftId, isTaxable = true)(request, messages).toString
 
       application.stop()
     }
 
     "populate the view correctly on a GET when the question has previously been answered" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
-        .set(HowDeedOfVariationCreatedPage, DeedOfVariation.values.head).success.value
+      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, true).success.value
 
       val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
 
-      val request = FakeRequest(GET, deedOfVariationRoute)
+      val request = FakeRequest(GET, setUpByLivingSettlorRoute)
 
-      val view = application.injector.instanceOf[HowDeedOfVariationCreatedView]
+      val view = application.injector.instanceOf[SetUpByLivingSettlorView]
 
       val result = route(application, request).value
 
       status(result) mustEqual OK
 
       contentAsString(result) mustEqual
-        view(form.fill(DeedOfVariation.values.head), fakeDraftId)(request, messages).toString
+        view(form.fill(true), fakeDraftId, isTaxable = true)(request, messages).toString
 
       application.stop()
     }
 
     "redirect to the next page when valid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
-
       val application =
-        applicationBuilder(userAnswers = Some(userAnswers)).build()
+        applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       val request =
-        FakeRequest(POST, deedOfVariationRoute)
-          .withFormUrlEncodedBody(("value", DeedOfVariation.options.head.value))
+        FakeRequest(POST, setUpByLivingSettlorRoute)
+          .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(application, request).value
 
@@ -99,24 +90,22 @@ class HowDeedOfVariationCreatedControllerSpec extends SpecBase {
 
     "return a Bad Request and errors when invalid data is submitted" in {
 
-      val userAnswers = emptyUserAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
-
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       val request =
-        FakeRequest(POST, deedOfVariationRoute)
-          .withFormUrlEncodedBody(("value", "invalid value"))
+        FakeRequest(POST, setUpByLivingSettlorRoute)
+          .withFormUrlEncodedBody(("value", ""))
 
-      val boundForm = form.bind(Map("value" -> "invalid value"))
+      val boundForm = form.bind(Map("value" -> ""))
 
-      val view = application.injector.instanceOf[HowDeedOfVariationCreatedView]
+      val view = application.injector.instanceOf[SetUpByLivingSettlorView]
 
       val result = route(application, request).value
 
       status(result) mustEqual BAD_REQUEST
 
       contentAsString(result) mustEqual
-        view(boundForm, fakeDraftId)(request, messages).toString
+        view(boundForm, fakeDraftId, isTaxable = true)(request, messages).toString
 
       application.stop()
     }
@@ -125,11 +114,12 @@ class HowDeedOfVariationCreatedControllerSpec extends SpecBase {
 
       val application = applicationBuilder(userAnswers = None).build()
 
-      val request = FakeRequest(GET, deedOfVariationRoute)
+      val request = FakeRequest(GET, setUpByLivingSettlorRoute)
 
       val result = route(application, request).value
 
       status(result) mustEqual SEE_OTHER
+
       redirectLocation(result).value mustEqual SessionExpiredController.onPageLoad.url
 
       application.stop()
@@ -140,8 +130,8 @@ class HowDeedOfVariationCreatedControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = None).build()
 
       val request =
-        FakeRequest(POST, deedOfVariationRoute)
-          .withFormUrlEncodedBody(("value", KindOfTrust.values.head.toString))
+        FakeRequest(POST, setUpByLivingSettlorRoute)
+          .withFormUrlEncodedBody(("value", "true"))
 
       val result = route(application, request).value
 
@@ -153,4 +143,3 @@ class HowDeedOfVariationCreatedControllerSpec extends SpecBase {
     }
   }
 }
-

--- a/test/generators/PageGenerators.scala
+++ b/test/generators/PageGenerators.scala
@@ -22,7 +22,7 @@ import pages.deceased_settlor._
 import pages.living_settlor._
 import pages.living_settlor.business.SettlorBusinessNamePage
 import pages.living_settlor.individual._
-import pages.trust_type.{HoldoverReliefYesNoPage, KindOfTrustPage, SetUpAfterSettlorDiedYesNoPage}
+import pages.trust_type.{HoldoverReliefYesNoPage, KindOfTrustPage, SetUpByLivingSettlorYesNoPage}
 
 trait PageGenerators {
 
@@ -83,8 +83,8 @@ trait PageGenerators {
   implicit lazy val arbitraryWasSettlorsAddressUKYesNoPage: Arbitrary[WasSettlorsAddressUKYesNoPage.type] =
     Arbitrary(WasSettlorsAddressUKYesNoPage)
 
-  implicit lazy val arbitrarySetUpAfterSettlorDiedPage: Arbitrary[SetUpAfterSettlorDiedYesNoPage.type] =
-    Arbitrary(SetUpAfterSettlorDiedYesNoPage)
+  implicit lazy val arbitrarySetUpByLivingSettlorYesNoPage: Arbitrary[SetUpByLivingSettlorYesNoPage.type] =
+    Arbitrary(SetUpByLivingSettlorYesNoPage)
 
   implicit lazy val arbitrarySettlorsUKAddressPage: Arbitrary[SettlorsUKAddressPage.type] =
     Arbitrary(SettlorsUKAddressPage)

--- a/test/generators/UserAnswersEntryGenerators.scala
+++ b/test/generators/UserAnswersEntryGenerators.scala
@@ -24,7 +24,7 @@ import pages.deceased_settlor._
 import pages.living_settlor._
 import pages.living_settlor.business.SettlorBusinessNamePage
 import pages.living_settlor.individual._
-import pages.trust_type.{HoldoverReliefYesNoPage, KindOfTrustPage, SetUpAfterSettlorDiedYesNoPage}
+import pages.trust_type.{HoldoverReliefYesNoPage, KindOfTrustPage, SetUpByLivingSettlorYesNoPage}
 import play.api.libs.json.{JsValue, Json}
 
 trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
@@ -173,10 +173,10 @@ trait UserAnswersEntryGenerators extends PageGenerators with ModelGenerators {
       } yield (page, value)
     }
 
-  implicit lazy val arbitrarySetUpAfterSettlorDiedUserAnswersEntry: Arbitrary[(SetUpAfterSettlorDiedYesNoPage.type, JsValue)] =
+  implicit lazy val arbitrarySetUpByLivingSettlorRouteUserAnswersEntry: Arbitrary[(SetUpByLivingSettlorYesNoPage.type, JsValue)] =
     Arbitrary {
       for {
-        page  <- arbitrary[SetUpAfterSettlorDiedYesNoPage.type]
+        page  <- arbitrary[SetUpByLivingSettlorYesNoPage.type]
         value <- arbitrary[Boolean].map(Json.toJson(_))
       } yield (page, value)
     }

--- a/test/generators/UserAnswersGenerator.scala
+++ b/test/generators/UserAnswersGenerator.scala
@@ -51,7 +51,7 @@ trait UserAnswersGenerator extends TryValues {
       arbitrary[(SettlorIndividualNamePage, JsValue)] ::
       arbitrary[(SettlorIndividualOrBusinessPage, JsValue)] ::
       arbitrary[(WasSettlorsAddressUKYesNoPage.type, JsValue)] ::
-      arbitrary[(SetUpAfterSettlorDiedYesNoPage.type, JsValue)] ::
+      arbitrary[(SetUpByLivingSettlorYesNoPage.type, JsValue)] ::
       arbitrary[(SettlorsUKAddressPage.type, JsValue)] ::
       arbitrary[(SettlorsNationalInsuranceYesNoPage.type, JsValue)] ::
       arbitrary[(SettlorsNamePage.type, JsValue)] ::

--- a/test/mapping/IndividualSettlorsMapperSpec.scala
+++ b/test/mapping/IndividualSettlorsMapperSpec.scala
@@ -26,6 +26,7 @@ import java.time.LocalDate
 
 class IndividualSettlorsMapperSpec extends SpecBase {
 
+  private val aliveAtRegistration: Boolean = true
   private val name: FullName = FullName("Joe", None, "Bloggs")
   private val date: LocalDate = LocalDate.parse("1996-02-03")
   private val nino: String = "AA000000A"
@@ -62,6 +63,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
         "NINO" in {
 
           val userAnswers: UserAnswers = emptyUserAnswers
+            .set(SettlorAliveYesNoPage(index), true).success.value
             .set(SettlorIndividualNamePage(index), name).success.value
             .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
             .set(SettlorIndividualNINOYesNoPage(index), true).success.value
@@ -70,6 +72,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
           val result = mapper.build(userAnswers).get
 
           result mustBe List(Settlor(
+            aliveAtRegistration = aliveAtRegistration,
             name = name,
             dateOfBirth = None,
             identification = Some(IdentificationType(
@@ -86,6 +89,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
         "UK address and passport" in {
 
           val userAnswers: UserAnswers = emptyUserAnswers
+            .set(SettlorAliveYesNoPage(index), true).success.value
             .set(SettlorIndividualNamePage(index), name).success.value
             .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
             .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -98,6 +102,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
           val result = mapper.build(userAnswers).get
 
           result mustBe List(Settlor(
+            aliveAtRegistration = aliveAtRegistration,
             name = name,
             dateOfBirth = None,
             identification = Some(IdentificationType(
@@ -114,6 +119,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
         "non-UK address and ID card" in {
 
           val userAnswers: UserAnswers = emptyUserAnswers
+            .set(SettlorAliveYesNoPage(index), true).success.value
             .set(SettlorIndividualNamePage(index), name).success.value
             .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
             .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -127,6 +133,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
           val result = mapper.build(userAnswers).get
 
           result mustBe List(Settlor(
+            aliveAtRegistration = aliveAtRegistration,
             name = name,
             dateOfBirth = None,
             identification = Some(IdentificationType(
@@ -143,6 +150,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
         "UK address and no passport/ID card" in {
 
           val userAnswers: UserAnswers = emptyUserAnswers
+            .set(SettlorAliveYesNoPage(index), true).success.value
             .set(SettlorIndividualNamePage(index), name).success.value
             .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
             .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -155,6 +163,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
           val result = mapper.build(userAnswers).get
 
           result mustBe List(Settlor(
+            aliveAtRegistration = aliveAtRegistration,
             name = name,
             dateOfBirth = None,
             identification = Some(IdentificationType(
@@ -171,6 +180,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
         "no identification" in {
 
           val userAnswers: UserAnswers = emptyUserAnswers
+            .set(SettlorAliveYesNoPage(index), true).success.value
             .set(SettlorIndividualNamePage(index), name).success.value
             .set(SettlorIndividualDateOfBirthYesNoPage(index), true).success.value
             .set(SettlorIndividualDateOfBirthPage(index), date).success.value
@@ -180,6 +190,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
           val result = mapper.build(userAnswers).get
 
           result mustBe List(Settlor(
+            aliveAtRegistration = aliveAtRegistration,
             name = name,
             dateOfBirth = Some(date),
             identification = None,
@@ -195,11 +206,13 @@ class IndividualSettlorsMapperSpec extends SpecBase {
         def name(index: Int): FullName = FullName("Name", None, s"$index")
 
         val userAnswers: UserAnswers = emptyUserAnswers
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(0), name(0)).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(0), false).success.value
           .set(SettlorIndividualNINOYesNoPage(0), false).success.value
           .set(SettlorAddressYesNoPage(0), false).success.value
 
+          .set(SettlorAliveYesNoPage(1), true).success.value
           .set(SettlorIndividualNamePage(1), name(1)).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(1), false).success.value
           .set(SettlorIndividualNINOYesNoPage(1), false).success.value
@@ -209,6 +222,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
 
         result mustBe List(
           Settlor(
+            aliveAtRegistration = aliveAtRegistration,
             name = name(0),
             dateOfBirth = None,
             identification = None,
@@ -217,6 +231,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
             legallyIncapable = None
           ),
           Settlor(
+            aliveAtRegistration = aliveAtRegistration,
             name = name(1),
             dateOfBirth = None,
             identification = None,
@@ -230,6 +245,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
       "country of nationality and residency unknown" in {
 
         val userAnswers: UserAnswers = emptyUserAnswers
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(CountryOfNationalityYesNoPage(index), false).success.value
@@ -241,6 +257,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
         val result = mapper.build(userAnswers).get
 
         result mustBe List(Settlor(
+          aliveAtRegistration = aliveAtRegistration,
           name = name,
           dateOfBirth = None,
           identification = None,
@@ -253,6 +270,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
       "UK country of nationality and residency" in {
 
         val userAnswers: UserAnswers = emptyUserAnswers
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(CountryOfNationalityYesNoPage(index), true).success.value
@@ -266,6 +284,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
         val result = mapper.build(userAnswers).get
 
         result mustBe List(Settlor(
+          aliveAtRegistration = aliveAtRegistration,
           name = name,
           dateOfBirth = None,
           identification = None,
@@ -278,6 +297,7 @@ class IndividualSettlorsMapperSpec extends SpecBase {
       "non-UK country of nationality and residency" in {
 
         val userAnswers: UserAnswers = emptyUserAnswers
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(CountryOfNationalityYesNoPage(index), true).success.value
@@ -293,11 +313,38 @@ class IndividualSettlorsMapperSpec extends SpecBase {
         val result = mapper.build(userAnswers).get
 
         result mustBe List(Settlor(
+          aliveAtRegistration = aliveAtRegistration,
           name = name,
           dateOfBirth = None,
           identification = None,
           countryOfResidence = Some("ES"),
           nationality = Some("FR"),
+          legallyIncapable = None
+        ))
+      }
+
+      "settlor is not alive at the time of registration" in {
+        val userAnswers: UserAnswers = emptyUserAnswers
+          .set(SettlorAliveYesNoPage(index), false).success.value
+          .set(SettlorIndividualNamePage(index), name).success.value
+          .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
+          .set(SettlorIndividualNINOYesNoPage(index), true).success.value
+          .set(SettlorIndividualNINOPage(index), nino).success.value
+          .set(MentalCapacityYesNoPage(index), YesNoDontKnow.Yes).success.value
+
+        val result = mapper.build(userAnswers).get
+
+        result mustBe List(Settlor(
+          aliveAtRegistration = false,
+          name = name,
+          dateOfBirth = None,
+          identification = Some(IdentificationType(
+            nino = Some(nino),
+            passport = None,
+            address = None
+          )),
+          countryOfResidence = None,
+          nationality = None,
           legallyIncapable = None
         ))
       }

--- a/test/mapping/SettlorsMapperSpec.scala
+++ b/test/mapping/SettlorsMapperSpec.scala
@@ -27,6 +27,7 @@ class SettlorsMapperSpec extends SpecBase {
   private val mockBusinessMapper: BusinessSettlorsMapper = mock[BusinessSettlorsMapper]
 
   private val individualSettlor: Settlor = Settlor(
+    aliveAtRegistration = true,
     name = FullName("Joe", None, "Bloggs"),
     dateOfBirth = None,
     identification = None,

--- a/test/mapping/TrustDetailsMapperSpec.scala
+++ b/test/mapping/TrustDetailsMapperSpec.scala
@@ -23,7 +23,7 @@ import models.pages.{FullName, IndividualOrBusiness, KindOfTrust}
 import models.{TrustDetailsType, UserAnswers}
 import pages.deceased_settlor.SettlorsNamePage
 import pages.living_settlor._
-import pages.living_settlor.individual.SettlorIndividualNamePage
+import pages.living_settlor.individual.{SettlorAliveYesNoPage, SettlorIndividualNamePage}
 import pages.trust_type._
 
 import java.time.LocalDate
@@ -52,9 +52,10 @@ class TrustDetailsMapperSpec extends SpecBase {
         "invalid user answers due to having living and deceased settlors" in {
 
           val userAnswers = flaggedAnswers
-            .set(SetUpAfterSettlorDiedYesNoPage, true).success.value
+            .set(SetUpByLivingSettlorYesNoPage, true).success.value
             .set(SettlorsNamePage, fullName).success.value
             .set(SettlorIndividualOrBusinessPage(0), IndividualOrBusiness.Individual).success.value
+            .set(SettlorAliveYesNoPage(0), true).success.value
             .set(SettlorIndividualNamePage(0), fullName).success.value
 
           val result = mapper.build(userAnswers)
@@ -65,12 +66,12 @@ class TrustDetailsMapperSpec extends SpecBase {
 
       "map user answers to trust details model" when {
 
-        val setupAfterSettlorDiedAnswers = flaggedAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, true).success.value
+        val SetUpByLivingSettlorViewAnswers = flaggedAnswers
+          .set(SetUpByLivingSettlorYesNoPage, true).success.value
 
         "setup after settlor died" in {
 
-          val userAnswers = setupAfterSettlorDiedAnswers
+          val userAnswers = SetUpByLivingSettlorViewAnswers
             .set(SettlorsNamePage, fullName).success.value
 
           val result = mapper.build(userAnswers).get
@@ -85,12 +86,12 @@ class TrustDetailsMapperSpec extends SpecBase {
 
         "not setup after settlor died" when {
 
-          val setupAfterSettlorDiedAnswers = flaggedAnswers
-            .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          val SetUpByLivingSettlorViewAnswers = flaggedAnswers
+            .set(SetUpByLivingSettlorYesNoPage, false).success.value
 
           "deed of variation" when {
 
-            val baseAnswers = setupAfterSettlorDiedAnswers
+            val baseAnswers = SetUpByLivingSettlorViewAnswers
               .set(KindOfTrustPage, KindOfTrust.Deed).success.value
 
             "set up in addition to will trust" in {
@@ -115,6 +116,7 @@ class TrustDetailsMapperSpec extends SpecBase {
                 .set(SetUpInAdditionToWillTrustYesNoPage, false).success.value
                 .set(HowDeedOfVariationCreatedPage, ReplacedWill).success.value
                 .set(SettlorIndividualOrBusinessPage(0), IndividualOrBusiness.Individual).success.value
+                .set(SettlorAliveYesNoPage(0), true).success.value
                 .set(SettlorIndividualNamePage(0), fullName).success.value
 
               val result = mapper.build(userAnswers).get
@@ -132,10 +134,11 @@ class TrustDetailsMapperSpec extends SpecBase {
 
             val holdoverReliefYesNo: Boolean = true
 
-            val userAnswers = setupAfterSettlorDiedAnswers
+            val userAnswers = SetUpByLivingSettlorViewAnswers
               .set(KindOfTrustPage, KindOfTrust.Intervivos).success.value
               .set(HoldoverReliefYesNoPage, holdoverReliefYesNo).success.value
               .set(SettlorIndividualOrBusinessPage(0), IndividualOrBusiness.Individual).success.value
+              .set(SettlorAliveYesNoPage(0), true).success.value
               .set(SettlorIndividualNamePage(0), fullName).success.value
 
             val result = mapper.build(userAnswers).get
@@ -150,9 +153,10 @@ class TrustDetailsMapperSpec extends SpecBase {
 
           "flat management" in {
 
-            val userAnswers = setupAfterSettlorDiedAnswers
+            val userAnswers = SetUpByLivingSettlorViewAnswers
               .set(KindOfTrustPage, KindOfTrust.FlatManagement).success.value
               .set(SettlorIndividualOrBusinessPage(0), IndividualOrBusiness.Individual).success.value
+              .set(SettlorAliveYesNoPage(0), true).success.value
               .set(SettlorIndividualNamePage(0), fullName).success.value
 
             val result = mapper.build(userAnswers).get
@@ -167,9 +171,10 @@ class TrustDetailsMapperSpec extends SpecBase {
 
           "heritage maintenance fund" in {
 
-            val userAnswers = setupAfterSettlorDiedAnswers
+            val userAnswers = SetUpByLivingSettlorViewAnswers
               .set(KindOfTrustPage, KindOfTrust.HeritageMaintenanceFund).success.value
               .set(SettlorIndividualOrBusinessPage(0), IndividualOrBusiness.Individual).success.value
+              .set(SettlorAliveYesNoPage(0), true).success.value
               .set(SettlorIndividualNamePage(0), fullName).success.value
 
             val result = mapper.build(userAnswers).get
@@ -188,11 +193,12 @@ class TrustDetailsMapperSpec extends SpecBase {
 
               val date: LocalDate = LocalDate.parse("1996-02-03")
 
-              val userAnswers = setupAfterSettlorDiedAnswers
+              val userAnswers = SetUpByLivingSettlorViewAnswers
                 .set(KindOfTrustPage, KindOfTrust.Employees).success.value
                 .set(EfrbsYesNoPage, true).success.value
                 .set(EfrbsStartDatePage, date).success.value
                 .set(SettlorIndividualOrBusinessPage(0), IndividualOrBusiness.Individual).success.value
+                .set(SettlorAliveYesNoPage(0), true).success.value
                 .set(SettlorIndividualNamePage(0), fullName).success.value
 
               val result = mapper.build(userAnswers).get
@@ -207,10 +213,11 @@ class TrustDetailsMapperSpec extends SpecBase {
 
             "not efrbs" in {
 
-              val userAnswers = setupAfterSettlorDiedAnswers
+              val userAnswers = SetUpByLivingSettlorViewAnswers
                 .set(KindOfTrustPage, KindOfTrust.Employees).success.value
                 .set(EfrbsYesNoPage, false).success.value
                 .set(SettlorIndividualOrBusinessPage(0), IndividualOrBusiness.Individual).success.value
+                .set(SettlorAliveYesNoPage(0), true).success.value
                 .set(SettlorIndividualNamePage(0), fullName).success.value
 
               val result = mapper.build(userAnswers).get
@@ -235,7 +242,7 @@ class TrustDetailsMapperSpec extends SpecBase {
 
         "set up after settlor died" in {
           val answers: UserAnswers = flaggedAnswers
-            .set(SetUpAfterSettlorDiedYesNoPage, true).success.value
+            .set(SetUpByLivingSettlorYesNoPage, true).success.value
             .set(SettlorsNamePage, fullName).success.value
 
           val result = mapper.build(answers)
@@ -244,8 +251,9 @@ class TrustDetailsMapperSpec extends SpecBase {
 
         "not set up after settlor died" in {
           val answers: UserAnswers = flaggedAnswers
-            .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+            .set(SetUpByLivingSettlorYesNoPage, false).success.value
             .set(SettlorIndividualOrBusinessPage(0), IndividualOrBusiness.Individual).success.value
+            .set(SettlorAliveYesNoPage(0), true).success.value
             .set(SettlorIndividualNamePage(0), fullName).success.value
 
           val result = mapper.build(answers)

--- a/test/mapping/reads/IndividualSettlorSpec.scala
+++ b/test/mapping/reads/IndividualSettlorSpec.scala
@@ -31,6 +31,7 @@ class IndividualSettlorSpec extends SpecBase with Matchers with OptionValues {
       val json = Json.parse(
         """
           |{
+          | "aliveAtRegistration": true,
           | "name": {
           |   "firstName": "John",
           |   "lastName": "Smith"
@@ -40,6 +41,7 @@ class IndividualSettlorSpec extends SpecBase with Matchers with OptionValues {
           |""".stripMargin)
 
       json.as[IndividualSettlor] mustBe IndividualSettlor(
+        aliveAtRegistration = true,
         name = FullName("John", None, "Smith"),
         dateOfBirth = None,
         nino = None,
@@ -56,6 +58,7 @@ class IndividualSettlorSpec extends SpecBase with Matchers with OptionValues {
       val json = Json.parse(
         """
           |{
+          | "aliveAtRegistration": true,
           | "name": {
           |   "firstName": "John",
           |   "lastName": "Smith"
@@ -65,6 +68,7 @@ class IndividualSettlorSpec extends SpecBase with Matchers with OptionValues {
           |""".stripMargin)
 
       json.as[IndividualSettlor] mustBe IndividualSettlor(
+        aliveAtRegistration = true,
         name = FullName("John", None, "Smith"),
         dateOfBirth = None,
         nino = None,

--- a/test/navigation/IndividualSettlorNavigatorSpec.scala
+++ b/test/navigation/IndividualSettlorNavigatorSpec.scala
@@ -36,6 +36,14 @@ class IndividualSettlorNavigatorSpec extends SpecBase {
 
       val baseAnswers: UserAnswers = emptyUserAnswers.copy(isTaxable = true)
 
+      "SettlorAliveYesNoPage" must {
+        val page = SettlorAliveYesNoPage(index)
+        "redirect to settlor individual name" in {
+          navigator.nextPage(page, fakeDraftId)(baseAnswers)
+            .mustBe(SettlorIndividualNameController.onPageLoad(index, fakeDraftId))
+        }
+      }
+
       "SettlorIndividualNamePage" must {
         val page = SettlorIndividualNamePage(index)
         "redirect to date of birth yes/no" in {
@@ -166,13 +174,24 @@ class IndividualSettlorNavigatorSpec extends SpecBase {
         "no" when {
 
           "NINO known" must {
-            "redirect to legally incapable yes/no" in {
+            "redirect to legally incapable yes/no if the settlor is alive at registration" in {
               val userAnswers = baseAnswers
+                .set(SettlorAliveYesNoPage(index), true).success.value
                 .set(SettlorIndividualNINOPage(index), nino).success.value
                 .set(page, false).success.value
 
               navigator.nextPage(page, fakeDraftId)(userAnswers)
                 .mustBe(MentalCapacityYesNoController.onPageLoad(index, fakeDraftId))
+            }
+
+            "redirect to check answers if the settlor is not alive at registration" in {
+              val userAnswers = baseAnswers
+                .set(SettlorAliveYesNoPage(index), false).success.value
+                .set(SettlorIndividualNINOPage(index), nino).success.value
+                .set(page, false).success.value
+
+              navigator.nextPage(page, fakeDraftId)(userAnswers)
+                .mustBe(SettlorIndividualAnswerController.onPageLoad(index, fakeDraftId))
             }
           }
 
@@ -192,13 +211,24 @@ class IndividualSettlorNavigatorSpec extends SpecBase {
         "yes" when {
 
           "NINO known" must {
-            "redirect to legally incapable yes/no" in {
+            "redirect to legally incapable yes/no if the settlor is alive at registration" in {
               val userAnswers = baseAnswers
+                .set(SettlorAliveYesNoPage(index), true).success.value
                 .set(SettlorIndividualNINOPage(index), nino).success.value
                 .set(page, true).success.value
 
               navigator.nextPage(page, fakeDraftId)(userAnswers)
                 .mustBe(MentalCapacityYesNoController.onPageLoad(index, fakeDraftId))
+            }
+
+            "redirect to check answers if the settlor is not alive at registration" in {
+              val userAnswers = baseAnswers
+                .set(SettlorAliveYesNoPage(index), false).success.value
+                .set(SettlorIndividualNINOPage(index), nino).success.value
+                .set(page, true).success.value
+
+              navigator.nextPage(page, fakeDraftId)(userAnswers)
+                .mustBe(SettlorIndividualAnswerController.onPageLoad(index, fakeDraftId))
             }
           }
 
@@ -225,13 +255,24 @@ class IndividualSettlorNavigatorSpec extends SpecBase {
       "CountryOfResidencyPage" when {
         val page = CountryOfResidencyPage(index)
         "NINO known" must {
-          "redirect to legally incapable yes/no" in {
+          "redirect to legally incapable yes/no if the settlor is alive at registration" in {
             val userAnswers = baseAnswers
+              .set(SettlorAliveYesNoPage(index), true).success.value
               .set(SettlorIndividualNINOPage(index), nino).success.value
               .set(page, "FR").success.value
 
             navigator.nextPage(page, fakeDraftId)(userAnswers)
               .mustBe(MentalCapacityYesNoController.onPageLoad(index, fakeDraftId))
+          }
+
+          "redirect to check answers if the settlor is not alive at registration" in {
+            val userAnswers = baseAnswers
+              .set(SettlorAliveYesNoPage(index), false).success.value
+              .set(SettlorIndividualNINOPage(index), nino).success.value
+              .set(page, "FR").success.value
+
+            navigator.nextPage(page, fakeDraftId)(userAnswers)
+              .mustBe(SettlorIndividualAnswerController.onPageLoad(index, fakeDraftId))
           }
         }
 
@@ -280,11 +321,22 @@ class IndividualSettlorNavigatorSpec extends SpecBase {
         }
 
         "no" must {
-          "redirect to legally incapable yes/no" in {
-            val userAnswers = baseAnswers.set(page, false).success.value
+          "redirect to legally incapable yes/no if the settlor is alive at registration" in {
+            val userAnswers = baseAnswers
+              .set(SettlorAliveYesNoPage(index), true).success.value
+              .set(page, false).success.value
 
             navigator.nextPage(page, fakeDraftId)(userAnswers)
               .mustBe(MentalCapacityYesNoController.onPageLoad(index, fakeDraftId))
+          }
+
+          "redirect to check answers if the settlor is not alive at registration" in {
+            val userAnswers = baseAnswers
+              .set(SettlorAliveYesNoPage(index), false).success.value
+              .set(page, false).success.value
+
+            navigator.nextPage(page, fakeDraftId)(userAnswers)
+              .mustBe(SettlorIndividualAnswerController.onPageLoad(index, fakeDraftId))
           }
         }
       }
@@ -349,9 +401,14 @@ class IndividualSettlorNavigatorSpec extends SpecBase {
 
       "SettlorIndividualPassportPage" must {
         val page = SettlorIndividualPassportPage(index)
-        "redirect to legally incapable yes/no" in {
-          navigator.nextPage(page, fakeDraftId)(baseAnswers)
+        "redirect to legally incapable yes/no if the settlor is alive at registration" in {
+          navigator.nextPage(page, fakeDraftId)(baseAnswers.set(SettlorAliveYesNoPage(index), true).success.value)
             .mustBe(MentalCapacityYesNoController.onPageLoad(index, fakeDraftId))
+        }
+
+        "redirect to check answers if the settlor is not alive at registration" in {
+          navigator.nextPage(page, fakeDraftId)(baseAnswers.set(SettlorAliveYesNoPage(index), false).success.value)
+            .mustBe(SettlorIndividualAnswerController.onPageLoad(index, fakeDraftId))
         }
       }
 
@@ -367,20 +424,34 @@ class IndividualSettlorNavigatorSpec extends SpecBase {
         }
 
         "no" must {
-          "redirect to legally incapable yes/no" in {
-            val userAnswers = baseAnswers.set(page, false).success.value
+          "redirect to legally incapable yes/no if the settlor is alive at registration" in {
+            val userAnswers = baseAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+              .set(page, false).success.value
 
             navigator.nextPage(page, fakeDraftId)(userAnswers)
               .mustBe(MentalCapacityYesNoController.onPageLoad(index, fakeDraftId))
+          }
+
+          "redirect to check answers if the settlor is not alive at registration" in {
+            val userAnswers = baseAnswers.set(SettlorAliveYesNoPage(index), false).success.value
+              .set(page, false).success.value
+
+            navigator.nextPage(page, fakeDraftId)(userAnswers)
+              .mustBe(SettlorIndividualAnswerController.onPageLoad(index, fakeDraftId))
           }
         }
       }
 
       "SettlorIndividualIDCardPage" must {
         val page = SettlorIndividualIDCardPage(index)
-        "redirect to legally incapable yes/no" in {
-          navigator.nextPage(page, fakeDraftId)(baseAnswers)
+        "redirect to legally incapable yes/no if the settlor is alive at registration" in {
+          navigator.nextPage(page, fakeDraftId)(baseAnswers.set(SettlorAliveYesNoPage(index), true).success.value)
             .mustBe(MentalCapacityYesNoController.onPageLoad(index, fakeDraftId))
+        }
+
+        "redirect to check answers if the settlor is not alive at registration" in {
+          navigator.nextPage(page, fakeDraftId)(baseAnswers.set(SettlorAliveYesNoPage(index), false).success.value)
+            .mustBe(SettlorIndividualAnswerController.onPageLoad(index, fakeDraftId))
         }
       }
 
@@ -504,11 +575,20 @@ class IndividualSettlorNavigatorSpec extends SpecBase {
         }
 
         "no" must {
-          "redirect to legally incapable yes/no" in {
-            val userAnswers = baseAnswers.set(page, false).success.value
+          "redirect to legally incapable yes/no if the settlor is alive at registration" in {
+            val userAnswers = baseAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+              .set(page, false).success.value
 
             navigator.nextPage(page, fakeDraftId)(userAnswers)
               .mustBe(MentalCapacityYesNoController.onPageLoad(index, fakeDraftId))
+          }
+
+          "redirect to check answers if the settlor is not alive at registration" in {
+            val userAnswers = baseAnswers.set(SettlorAliveYesNoPage(index), false).success.value
+              .set(page, false).success.value
+
+            navigator.nextPage(page, fakeDraftId)(userAnswers)
+              .mustBe(SettlorIndividualAnswerController.onPageLoad(index, fakeDraftId))
           }
         }
       }
@@ -516,11 +596,20 @@ class IndividualSettlorNavigatorSpec extends SpecBase {
       "UkCountryOfResidencyYesNoPage" when {
         val page = UkCountryOfResidencyYesNoPage(index)
         "yes" must {
-          "redirect to legally incapable yes/no" in {
-            val userAnswers = baseAnswers.set(page, true).success.value
+          "redirect to legally incapable yes/no if the settlor is not alive at registration" in {
+            val userAnswers = baseAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+              .set(page, true).success.value
 
             navigator.nextPage(page, fakeDraftId)(userAnswers)
               .mustBe(MentalCapacityYesNoController.onPageLoad(index, fakeDraftId))
+          }
+
+          "redirect to check answers if the settlor is not alive at registration" in {
+            val userAnswers = baseAnswers.set(SettlorAliveYesNoPage(index), false).success.value
+              .set(page, true).success.value
+
+            navigator.nextPage(page, fakeDraftId)(userAnswers)
+              .mustBe(SettlorIndividualAnswerController.onPageLoad(index, fakeDraftId))
           }
         }
 
@@ -536,11 +625,19 @@ class IndividualSettlorNavigatorSpec extends SpecBase {
 
       "CountryOfResidencyPage" must {
         val page = CountryOfResidencyPage(index)
-        "redirect to legally incapable yes/no" in {
-          val userAnswers = baseAnswers.set(page, "FR").success.value
+        "redirect to legally incapable yes/no if the settlor is alive at registration" in {
+          val userAnswers = baseAnswers.set(SettlorAliveYesNoPage(index), true).success.value
+            .set(page, "FR").success.value
 
           navigator.nextPage(page, fakeDraftId)(userAnswers)
             .mustBe(MentalCapacityYesNoController.onPageLoad(index, fakeDraftId))
+        }
+
+        "redirect to check answers if the settlor is not alive at registration" in {
+          val userAnswers = baseAnswers.set(page, "FR").success.value
+
+          navigator.nextPage(page, fakeDraftId)(userAnswers)
+            .mustBe(SettlorIndividualAnswerController.onPageLoad(index, fakeDraftId))
         }
       }
 

--- a/test/navigation/SettlorNavigatorSpec.scala
+++ b/test/navigation/SettlorNavigatorSpec.scala
@@ -84,7 +84,7 @@ class SettlorNavigatorSpec extends SpecBase {
               }).set(AddASettlorPage, YesNow).success.value
 
               navigator.nextPage(AddASettlorPage, fakeDraftId)(userAnswers)
-                .mustBe(controllers.living_settlor.individual.routes.SettlorIndividualNameController.onPageLoad(MAX, fakeDraftId))
+                .mustBe(controllers.living_settlor.individual.routes.SettlorAliveYesNoController.onPageLoad(MAX, fakeDraftId))
             }
           }
         }
@@ -115,7 +115,7 @@ class SettlorNavigatorSpec extends SpecBase {
           val userAnswers = emptyUserAnswers.set(AddASettlorYesNoPage, true).success.value
 
           navigator.nextPage(AddASettlorYesNoPage, fakeDraftId)(userAnswers)
-            .mustBe(controllers.trust_type.routes.SetUpAfterSettlorDiedController.onPageLoad(fakeDraftId))
+            .mustBe(controllers.trust_type.routes.SetUpByLivingSettlorController.onPageLoad(fakeDraftId))
         }
       }
 
@@ -138,7 +138,7 @@ class SettlorNavigatorSpec extends SpecBase {
           val userAnswers = emptyUserAnswers.set(SettlorIndividualOrBusinessPage(index), Individual).success.value
 
           navigator.nextPage(SettlorIndividualOrBusinessPage(index), fakeDraftId)(userAnswers)
-            .mustBe(controllers.living_settlor.individual.routes.SettlorIndividualNameController.onPageLoad(index, fakeDraftId))
+            .mustBe(controllers.living_settlor.individual.routes.SettlorAliveYesNoController.onPageLoad(index, fakeDraftId))
         }
       }
 

--- a/test/navigation/TrustTypeNavigatorSpec.scala
+++ b/test/navigation/TrustTypeNavigatorSpec.scala
@@ -31,22 +31,22 @@ class TrustTypeNavigatorSpec extends SpecBase {
 
       val baseAnswers: UserAnswers = emptyUserAnswers.copy(isTaxable = true)
 
-      "SetUpAfterSettlorDiedYesNoPage" when {
+      "setUpByLivingSettlorYesNoPage" when {
 
-        "yes" must {
+        "no" must {
           "redirect to Deceased Settlor Name" in {
-            val userAnswers = baseAnswers.set(SetUpAfterSettlorDiedYesNoPage, true).success.value
+            val userAnswers = baseAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
-            navigator.nextPage(SetUpAfterSettlorDiedYesNoPage, fakeDraftId)(userAnswers)
+            navigator.nextPage(SetUpByLivingSettlorYesNoPage, fakeDraftId)(userAnswers)
               .mustBe(controllers.deceased_settlor.routes.SettlorsNameController.onPageLoad(fakeDraftId))
           }
         }
 
-        "no" must {
+        "yes" must {
           "redirect to Kind of Trust" in {
-            val userAnswers = baseAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+            val userAnswers = baseAnswers.set(SetUpByLivingSettlorYesNoPage, true).success.value
 
-            navigator.nextPage(SetUpAfterSettlorDiedYesNoPage, fakeDraftId)(userAnswers)
+            navigator.nextPage(SetUpByLivingSettlorYesNoPage, fakeDraftId)(userAnswers)
               .mustBe(controllers.trust_type.routes.KindOfTrustController.onPageLoad(fakeDraftId))
           }
         }
@@ -168,22 +168,22 @@ class TrustTypeNavigatorSpec extends SpecBase {
 
       val baseAnswers: UserAnswers = emptyUserAnswers.copy(isTaxable = false)
 
-      "SetUpAfterSettlorDiedYesNoPage" when {
+      "setUpByLivingSettlorYesNoPage" when {
 
-        "yes" must {
+        "no" must {
           "redirect to Deceased Settlor Name" in {
-            val userAnswers = baseAnswers.set(SetUpAfterSettlorDiedYesNoPage, true).success.value
+            val userAnswers = baseAnswers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
-            navigator.nextPage(SetUpAfterSettlorDiedYesNoPage, fakeDraftId)(userAnswers)
+            navigator.nextPage(SetUpByLivingSettlorYesNoPage, fakeDraftId)(userAnswers)
               .mustBe(controllers.deceased_settlor.routes.SettlorsNameController.onPageLoad(fakeDraftId))
           }
         }
 
-        "no" must {
+        "yes" must {
           "redirect to Individual or Business" in {
-            val userAnswers = baseAnswers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+            val userAnswers = baseAnswers.set(SetUpByLivingSettlorYesNoPage, true).success.value
 
-            navigator.nextPage(SetUpAfterSettlorDiedYesNoPage, fakeDraftId)(userAnswers)
+            navigator.nextPage(SetUpByLivingSettlorYesNoPage, fakeDraftId)(userAnswers)
               .mustBe(controllers.living_settlor.routes.SettlorIndividualOrBusinessController.onPageLoad(0, fakeDraftId))
           }
         }

--- a/test/pages/RegistrationProgressSpec.scala
+++ b/test/pages/RegistrationProgressSpec.scala
@@ -21,6 +21,7 @@ import models.pages.AddASettlor.NoComplete
 import models.pages.IndividualOrBusiness._
 import models.pages.Status._
 import models.pages.{FullName, KindOfTrust}
+import pages.living_settlor.individual.SettlorAliveYesNoPage
 import pages.living_settlor.{SettlorIndividualOrBusinessPage, business => businessPages, individual => individualPages}
 import pages.trust_type._
 import pages.{deceased_settlor => deceasedPages}
@@ -34,7 +35,7 @@ class RegistrationProgressSpec extends SpecBase {
 
   "Registration progress" must {
 
-    "return None if SetUpAfterSettlorDiedYesNoPage not answered" in {
+    "return None if setUpByLivingSettlorYesNoPage not answered" in {
 
       val result = registrationProgress.settlorsStatus(emptyUserAnswers)
 
@@ -46,7 +47,7 @@ class RegistrationProgressSpec extends SpecBase {
       "setup after settlor died and deceased settlor incomplete" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, true).success.value
+          .set(SetUpByLivingSettlorYesNoPage, true).success.value
 
         val result = registrationProgress.settlorsStatus(userAnswers)
 
@@ -56,7 +57,7 @@ class RegistrationProgressSpec extends SpecBase {
       "setup in addition to will trust and deceased settlor incomplete" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(KindOfTrustPage, KindOfTrust.Deed).success.value
           .set(SetUpInAdditionToWillTrustYesNoPage, true).success.value
 
@@ -68,7 +69,7 @@ class RegistrationProgressSpec extends SpecBase {
       "not setup in addition to will trust and no living settlors" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(KindOfTrustPage, KindOfTrust.Deed).success.value
           .set(SetUpInAdditionToWillTrustYesNoPage, false).success.value
 
@@ -80,9 +81,10 @@ class RegistrationProgressSpec extends SpecBase {
       "there is an incomplete living settlor" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(KindOfTrustPage, KindOfTrust.HeritageMaintenanceFund).success.value
           .set(SettlorIndividualOrBusinessPage(0), Individual).success.value
+          .set(SettlorAliveYesNoPage(0), true).success.value
           .set(individualPages.SettlorIndividualNamePage(0), name).success.value
           .set(LivingSettlorStatus(0), Completed).success.value
           .set(SettlorIndividualOrBusinessPage(1), Business).success.value
@@ -99,7 +101,7 @@ class RegistrationProgressSpec extends SpecBase {
       "setup after settlor died and deceased settlor complete" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, true).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(deceasedPages.SettlorsNamePage, name).success.value
           .set(DeceasedSettlorStatus, Completed).success.value
 
@@ -111,7 +113,7 @@ class RegistrationProgressSpec extends SpecBase {
       "setup in addition to will trust and deceased settlor completed" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, true).success.value
           .set(KindOfTrustPage, KindOfTrust.Deed).success.value
           .set(SetUpInAdditionToWillTrustYesNoPage, true).success.value
           .set(deceasedPages.SettlorsNamePage, name).success.value
@@ -125,10 +127,11 @@ class RegistrationProgressSpec extends SpecBase {
       "not setup in addition to will trust and complete living settlors" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, true).success.value
           .set(KindOfTrustPage, KindOfTrust.Deed).success.value
           .set(SetUpInAdditionToWillTrustYesNoPage, false).success.value
           .set(SettlorIndividualOrBusinessPage(0), Individual).success.value
+          .set(SettlorAliveYesNoPage(0), true).success.value
           .set(individualPages.SettlorIndividualNamePage(0), name).success.value
           .set(LivingSettlorStatus(0), Completed).success.value
           .set(AddASettlorPage, NoComplete).success.value
@@ -141,9 +144,10 @@ class RegistrationProgressSpec extends SpecBase {
       "there are no incomplete living settlors" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, true).success.value
           .set(KindOfTrustPage, KindOfTrust.HeritageMaintenanceFund).success.value
           .set(SettlorIndividualOrBusinessPage(0), Individual).success.value
+          .set(SettlorAliveYesNoPage(0), true).success.value
           .set(individualPages.SettlorIndividualNamePage(0), name).success.value
           .set(LivingSettlorStatus(0), Completed).success.value
           .set(SettlorIndividualOrBusinessPage(1), Business).success.value

--- a/test/pages/living_settlor/SettlorIndividualOrBusinessPageSpec.scala
+++ b/test/pages/living_settlor/SettlorIndividualOrBusinessPageSpec.scala
@@ -42,7 +42,7 @@ class SettlorIndividualOrBusinessPageSpec extends PageBehaviours {
     forAll(arbitrary[UserAnswers], arbitrary[String]) {
       (initial, str) =>
         val answers: UserAnswers = initial
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(KindOfTrustPage, KindOfTrust.Employees).success.value
           .set(SettlorIndividualOrBusinessPage(0), IndividualOrBusiness.Business).success.value
           .set(SettlorBusinessNamePage(0), "AWS").success.value
@@ -73,10 +73,11 @@ class SettlorIndividualOrBusinessPageSpec extends PageBehaviours {
     forAll(arbitrary[UserAnswers], arbitrary[String]) {
       (initial, str) =>
         val answers: UserAnswers = initial
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(KindOfTrustPage, KindOfTrust.Intervivos).success.value
           .set(HoldoverReliefYesNoPage, true).success.value
           .set(SettlorIndividualOrBusinessPage(0), IndividualOrBusiness.Individual).success.value
+          .set(SettlorAliveYesNoPage(0), true).success.value
           .set(SettlorIndividualNamePage(0), FullName("First", None, "Last")).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(0), true).success.value
           .set(LivingSettlorStatus(0), InProgress).success.value

--- a/test/pages/living_settlor/individual/SettlorAliveYesNoPageSpec.scala
+++ b/test/pages/living_settlor/individual/SettlorAliveYesNoPageSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.living_settlor.individual
+
+import models.{UserAnswers, YesNoDontKnow}
+import pages.behaviours.PageBehaviours
+import org.scalacheck.Arbitrary.arbitrary
+import pages.living_settlor.individual.mld5.MentalCapacityYesNoPage
+
+class SettlorAliveYesNoPageSpec extends PageBehaviours {
+
+  "SettlorAliveYesNoPage" must {
+
+    beRetrievable[Boolean](SettlorAliveYesNoPage(0))
+
+    beSettable[Boolean](SettlorAliveYesNoPage(0))
+
+    beRemovable[Boolean](SettlorAliveYesNoPage(0))
+  }
+
+  "remove data for mental capacity question" when {
+
+    val page = SettlorAliveYesNoPage(0)
+
+    "set to false" in {
+      forAll(arbitrary[UserAnswers]) {
+        initial =>
+          val answers: UserAnswers = initial.set(page, true).success.value
+            .set(MentalCapacityYesNoPage(0), YesNoDontKnow.Yes).success.value
+
+          val result = answers.set(page, false).success.value
+
+          result.get(MentalCapacityYesNoPage(0)) must not be defined
+      }
+    }
+  }
+}

--- a/test/pages/trust_type/SetUpByLivingSettlorYesNoPageSpec.scala
+++ b/test/pages/trust_type/SetUpByLivingSettlorYesNoPageSpec.scala
@@ -28,15 +28,15 @@ import sections.{DeceasedSettlor, LivingSettlors}
 
 import java.time.LocalDate
 
-class SetUpAfterSettlorDiedYesNoPageSpec extends PageBehaviours {
+class SetUpByLivingSettlorYesNoPageSpec extends PageBehaviours {
 
-  "SetUpAfterSettlorDiedPage" must {
+  "SetUpByLivingSettlorPage" must {
 
-    beRetrievable[Boolean](SetUpAfterSettlorDiedYesNoPage)
+    beRetrievable[Boolean](SetUpByLivingSettlorYesNoPage)
 
-    beSettable[Boolean](SetUpAfterSettlorDiedYesNoPage)
+    beSettable[Boolean](SetUpByLivingSettlorYesNoPage)
 
-    beRemovable[Boolean](SetUpAfterSettlorDiedYesNoPage)
+    beRemovable[Boolean](SetUpByLivingSettlorYesNoPage)
   }
 
   "implement cleanup" when {
@@ -49,13 +49,13 @@ class SetUpAfterSettlorDiedYesNoPageSpec extends PageBehaviours {
           forAll(arbitrary[UserAnswers], arbitrary[String]) {
             (initial, str) =>
               val answers: UserAnswers = initial
-                .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+                .set(SetUpByLivingSettlorYesNoPage, false).success.value
                 .set(KindOfTrustPage, KindOfTrust.Deed).success.value
                 .set(SetUpInAdditionToWillTrustYesNoPage, true).success.value
                 .set(SettlorsNamePage, FullName(str, None, str)).success.value
                 .set(DeceasedSettlorStatus, Status.Completed).success.value
 
-              val result = answers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+              val result = answers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
               result.get(DeceasedSettlor) mustBe defined
           }
@@ -68,11 +68,11 @@ class SetUpAfterSettlorDiedYesNoPageSpec extends PageBehaviours {
           forAll(arbitrary[UserAnswers], arbitrary[String]) {
             (initial, str) =>
               val answers: UserAnswers = initial
-                .set(SetUpAfterSettlorDiedYesNoPage, true).success.value
+                .set(SetUpByLivingSettlorYesNoPage, false).success.value
                 .set(SettlorsNamePage, FullName(str, None, str)).success.value
                 .set(DeceasedSettlorStatus, Status.Completed).success.value
 
-              val result = answers.set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+              val result = answers.set(SetUpByLivingSettlorYesNoPage, true).success.value
 
               result.get(DeceasedSettlor) mustNot be(defined)
           }
@@ -85,7 +85,7 @@ class SetUpAfterSettlorDiedYesNoPageSpec extends PageBehaviours {
       forAll(arbitrary[UserAnswers], arbitrary[String], arbitrary[LocalDate]) {
         (initial, str, date) =>
           val answers: UserAnswers = initial
-            .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+            .set(SetUpByLivingSettlorYesNoPage, true).success.value
             .set(KindOfTrustPage, KindOfTrust.Intervivos).success.value
             .set(SetUpInAdditionToWillTrustYesNoPage, false).success.value
             .set(HowDeedOfVariationCreatedPage, DeedOfVariation.ReplacedWill).success.value
@@ -97,7 +97,7 @@ class SetUpAfterSettlorDiedYesNoPageSpec extends PageBehaviours {
             .set(SettlorBusinessNamePage(0), str).success.value
             .set(LivingSettlorStatus(1), Status.Completed).success.value
 
-          val result = answers.set(SetUpAfterSettlorDiedYesNoPage, true).success.value
+          val result = answers.set(SetUpByLivingSettlorYesNoPage, false).success.value
 
           result.get(KindOfTrustPage) mustNot be(defined)
           result.get(SetUpInAdditionToWillTrustYesNoPage) mustNot be(defined)

--- a/test/repositories/SubmissionSetFactorySpec.scala
+++ b/test/repositories/SubmissionSetFactorySpec.scala
@@ -90,7 +90,7 @@ class SubmissionSetFactorySpec extends SpecBase {
 
             val settlors: Settlors = Settlors(
               settlor = Some(List(
-                Settlor(name, None, None, None, None, None)
+                Settlor(aliveAtRegistration = true, name, None, None, None, None, None)
               )),
               settlorCompany = None
             )

--- a/test/utils/print/LivingSettlorPrintHelperSpec.scala
+++ b/test/utils/print/LivingSettlorPrintHelperSpec.scala
@@ -64,6 +64,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val userAnswers = emptyUserAnswers
           .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -72,6 +73,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualNINOYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualNINOYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -85,6 +87,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val userAnswers = emptyUserAnswers
           .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), true).success.value
           .set(SettlorIndividualDateOfBirthPage(index), date).success.value
@@ -94,6 +97,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualDateOfBirth.checkYourAnswersLabel", answer = Html("3 February 1996"), changeUrl = Some(SettlorIndividualDateOfBirthController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -108,6 +112,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val userAnswers = emptyUserAnswers
           .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -120,6 +125,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualNINOYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualNINOYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -137,6 +143,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val userAnswers = emptyUserAnswers
           .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -149,6 +156,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualNINOYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualNINOYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -166,6 +174,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val userAnswers = emptyUserAnswers
           .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -179,6 +188,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualNINOYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualNINOYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -195,6 +205,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
       val baseAnswers: UserAnswers = emptyUserAnswers
         .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+        .set(SettlorAliveYesNoPage(index), true).success.value
         .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
 
@@ -211,6 +222,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualCountryOfNationalityYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(CountryOfNationalityYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -238,6 +250,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualCountryOfNationalityYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(CountryOfNationalityYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -269,6 +282,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualCountryOfNationalityYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(CountryOfNationalityYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -284,8 +298,106 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         assertThatUserAnswersProduceExpectedAnswerRows(userAnswers, expectedAnswerRows)
       }
+
+      "include prefix in the message key when defined" when {
+
+        "UK residency, UK address and Passport pages" in {
+
+          val prefix = "PastTense"
+
+          val baseAnswers = emptyUserAnswers
+            .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+            .set(SettlorAliveYesNoPage(index), false).success.value
+
+          val pagesWithPrefix = baseAnswers
+            .set(SettlorIndividualNamePage(index), name).success.value
+            .set(SettlorIndividualDateOfBirthPage(index), date).success.value
+            .set(UkCountryOfNationalityYesNoPage(index), true).success.value
+            .set(CountryOfResidencyYesNoPage(index), true).success.value
+            .set(UkCountryOfResidencyYesNoPage(index), true).success.value
+            .set(SettlorAddressYesNoPage(index), true).success.value
+            .set(SettlorAddressUKYesNoPage(index), true).success.value
+            .set(SettlorAddressUKPage(index), ukAddress).success.value
+            .set(SettlorIndividualPassportPage(index), passportOrIdCardDetails).success.value
+            .set(LivingSettlorStatus(index), Completed).success.value
+
+
+          val expectedAnswerRows = Seq(
+            AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualName$prefix.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
+            AnswerRow(label = s"settlorIndividualDateOfBirth$prefix.checkYourAnswersLabel", answer = Html("3 February 1996"), changeUrl = Some(SettlorIndividualDateOfBirthController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualUkCountryOfNationalityYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(UkCountryOfNationalityYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualCountryOfResidencyYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(CountryOfResidencyYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualUkCountryOfResidencyYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(UkCountryOfResidencyYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorIndividualAddressYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressUKYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorIndividualAddressUKYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressUK$prefix.checkYourAnswersLabel", answer = Html("Line 1<br />Line 2<br />Line 3<br />Line 4<br />AB11AB"), changeUrl = Some(SettlorIndividualAddressUKController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualPassport$prefix.checkYourAnswersLabel", answer = Html("United Kingdom<br />0987654321<br />3 February 1996"), changeUrl = Some(SettlorIndividualPassportController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString)
+          )
+
+          val checkDetailsSection = livingSettlorPrintHelper.checkDetailsSection(pagesWithPrefix, name.toString, fakeDraftId, index, Some(prefix))
+
+          checkDetailsSection mustEqual AnswerSection(
+            headingKey = None,
+            rows = expectedAnswerRows,
+            sectionKey = None,
+            headingArgs = Seq(index + 1)
+          )
+        }
+
+        "Non-UK residency, International address and ID Card pages" in {
+
+          val prefix = "PastTense"
+
+          val baseAnswers = emptyUserAnswers
+            .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+            .set(SettlorAliveYesNoPage(index), false).success.value
+
+          val pagesWithPrefix = baseAnswers
+            .set(SettlorIndividualNamePage(index), name).success.value
+            .set(SettlorIndividualDateOfBirthPage(index), date).success.value
+            .set(UkCountryOfNationalityYesNoPage(index), false).success.value
+            .set(CountryOfNationalityPage(index), "FR").success.value
+            .set(CountryOfResidencyYesNoPage(index), true).success.value
+            .set(UkCountryOfResidencyYesNoPage(index), false).success.value
+            .set(CountryOfResidencyPage(index), "FR").success.value
+            .set(SettlorAddressYesNoPage(index), true).success.value
+            .set(SettlorAddressUKYesNoPage(index), false).success.value
+            .set(SettlorAddressInternationalPage(index), nonUkAddress).success.value
+            .set(SettlorIndividualIDCardPage(index), passportOrIdCardDetails).success.value
+            .set(LivingSettlorStatus(index), Completed).success.value
+
+
+          val expectedAnswerRows = Seq(
+            AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualName$prefix.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
+            AnswerRow(label = s"settlorIndividualDateOfBirth$prefix.checkYourAnswersLabel", answer = Html("3 February 1996"), changeUrl = Some(SettlorIndividualDateOfBirthController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualUkCountryOfNationalityYesNo$prefix.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(UkCountryOfNationalityYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualCountryOfNationality$prefix.checkYourAnswersLabel", answer = Html("France"), changeUrl = Some(CountryOfNationalityController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualCountryOfResidencyYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(CountryOfResidencyYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualUkCountryOfResidencyYesNo$prefix.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(UkCountryOfResidencyYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualCountryOfResidency$prefix.checkYourAnswersLabel", answer = Html("France"), changeUrl = Some(CountryOfResidencyController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorIndividualAddressYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressUKYesNo$prefix.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualAddressUKYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressInternational$prefix.checkYourAnswersLabel", answer = Html("Line 1<br />Line 2<br />Line 3<br />France"), changeUrl = Some(SettlorIndividualAddressInternationalController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualIDCard$prefix.checkYourAnswersLabel", answer = Html("United Kingdom<br />0987654321<br />3 February 1996"), changeUrl = Some(SettlorIndividualIDCardController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString)
+          )
+
+          val checkDetailsSection = livingSettlorPrintHelper.checkDetailsSection(pagesWithPrefix, name.toString, fakeDraftId, index, Some(prefix))
+
+          checkDetailsSection mustEqual AnswerSection(
+            headingKey = None,
+            rows = expectedAnswerRows,
+            sectionKey = None,
+            headingArgs = Seq(index + 1)
+          )
+        }
+      }
     }
   }
+
 
   private def assertThatUserAnswersProduceExpectedAnswerRows(userAnswers: UserAnswers,
                                                              expectedAnswerRows: Seq[AnswerRow]): Assertion = {

--- a/test/utils/print/TrustTypePrintHelperSpec.scala
+++ b/test/utils/print/TrustTypePrintHelperSpec.scala
@@ -41,13 +41,13 @@ class TrustTypePrintHelperSpec extends SpecBase {
       "deed of variation set up to replace will trust" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(KindOfTrustPage, KindOfTrust.Deed).success.value
           .set(SetUpInAdditionToWillTrustYesNoPage, false).success.value
           .set(HowDeedOfVariationCreatedPage, DeedOfVariation.ReplacedWill)(DeedOfVariation.writes).success.value
 
         val expectedAnswerRows = Seq(
-          AnswerRow(label = "setUpAfterSettlorDiedYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SetUpAfterSettlorDiedController.onPageLoad(fakeDraftId).url)),
+          AnswerRow(label = "setUpByLivingSettlorYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SetUpByLivingSettlorController.onPageLoad(fakeDraftId).url)),
           AnswerRow(label = "kindOfTrust.checkYourAnswersLabel", answer = Html("A trust through a Deed of Variation or family agreement"), changeUrl = Some(KindOfTrustController.onPageLoad(fakeDraftId).url)),
           AnswerRow(label = "setUpInAdditionToWillTrustYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(AdditionToWillTrustYesNoController.onPageLoad(fakeDraftId).url)),
           AnswerRow(label = "howDeedOfVariationCreated.checkYourAnswersLabel", answer = Html("to replace a will trust"), changeUrl = Some(HowDeedOfVariationCreatedController.onPageLoad(fakeDraftId).url))
@@ -59,12 +59,12 @@ class TrustTypePrintHelperSpec extends SpecBase {
       "intervivos" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(KindOfTrustPage, KindOfTrust.Intervivos).success.value
           .set(HoldoverReliefYesNoPage, true).success.value
 
         val expectedAnswerRows = Seq(
-          AnswerRow(label = "setUpAfterSettlorDiedYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SetUpAfterSettlorDiedController.onPageLoad(fakeDraftId).url)),
+          AnswerRow(label = "setUpByLivingSettlorYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SetUpByLivingSettlorController.onPageLoad(fakeDraftId).url)),
           AnswerRow(label = "kindOfTrust.checkYourAnswersLabel", answer = Html("A trust created during their lifetime to gift or transfer assets"), changeUrl = Some(KindOfTrustController.onPageLoad(fakeDraftId).url)),
           AnswerRow(label = "holdoverReliefYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(HoldoverReliefYesNoController.onPageLoad(fakeDraftId).url))
         )
@@ -75,11 +75,11 @@ class TrustTypePrintHelperSpec extends SpecBase {
       "flat management" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(KindOfTrustPage, KindOfTrust.FlatManagement).success.value
 
         val expectedAnswerRows = Seq(
-          AnswerRow(label = "setUpAfterSettlorDiedYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SetUpAfterSettlorDiedController.onPageLoad(fakeDraftId).url)),
+          AnswerRow(label = "setUpByLivingSettlorYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SetUpByLivingSettlorController.onPageLoad(fakeDraftId).url)),
           AnswerRow(label = "kindOfTrust.checkYourAnswersLabel", answer = Html("A trust for a building or building with tenants"), changeUrl = Some(KindOfTrustController.onPageLoad(fakeDraftId).url))
         )
 
@@ -89,11 +89,11 @@ class TrustTypePrintHelperSpec extends SpecBase {
       "heritage maintenance fund" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(KindOfTrustPage, KindOfTrust.HeritageMaintenanceFund).success.value
 
         val expectedAnswerRows = Seq(
-          AnswerRow(label = "setUpAfterSettlorDiedYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SetUpAfterSettlorDiedController.onPageLoad(fakeDraftId).url)),
+          AnswerRow(label = "setUpByLivingSettlorYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SetUpByLivingSettlorController.onPageLoad(fakeDraftId).url)),
           AnswerRow(label = "kindOfTrust.checkYourAnswersLabel", answer = Html("A trust for the repair of historic buildings"), changeUrl = Some(KindOfTrustController.onPageLoad(fakeDraftId).url))
         )
 
@@ -103,13 +103,13 @@ class TrustTypePrintHelperSpec extends SpecBase {
       "trust for employees of a company (EFRBS)" in {
 
         val userAnswers = emptyUserAnswers
-          .set(SetUpAfterSettlorDiedYesNoPage, false).success.value
+          .set(SetUpByLivingSettlorYesNoPage, false).success.value
           .set(KindOfTrustPage, KindOfTrust.Employees).success.value
           .set(EfrbsYesNoPage, true).success.value
           .set(EfrbsStartDatePage, date).success.value
 
         val expectedAnswerRows = Seq(
-          AnswerRow(label = "setUpAfterSettlorDiedYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SetUpAfterSettlorDiedController.onPageLoad(fakeDraftId).url)),
+          AnswerRow(label = "setUpByLivingSettlorYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SetUpByLivingSettlorController.onPageLoad(fakeDraftId).url)),
           AnswerRow(label = "kindOfTrust.checkYourAnswersLabel", answer = Html("A trust for the employees of a company"), changeUrl = Some(KindOfTrustController.onPageLoad(fakeDraftId).url)),
           AnswerRow(label = "employerFinancedRbsYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(EmployerFinancedRbsYesNoController.onPageLoad(fakeDraftId).url)),
           AnswerRow(label = "employerFinancedRbsStartDate.checkYourAnswersLabel", answer = Html("3 February 1996"), changeUrl = Some(EmployerFinancedRbsStartDateController.onPageLoad(fakeDraftId).url))

--- a/test/views/SettlorInfoViewSpec.scala
+++ b/test/views/SettlorInfoViewSpec.scala
@@ -70,7 +70,7 @@ class SettlorInfoViewSpec extends ViewBehaviours {
 
       behave like pageWithBackLink(applyView)
 
-      behave like pageWithContinueButton(applyView, routes.SetUpAfterSettlorDiedController.onPageLoad(fakeDraftId).url)
+      behave like pageWithContinueButton(applyView, routes.SetUpByLivingSettlorController.onPageLoad(fakeDraftId).url)
     }
 
     "non-taxable" must {
@@ -113,7 +113,7 @@ class SettlorInfoViewSpec extends ViewBehaviours {
 
       behave like pageWithBackLink(applyView)
 
-      behave like pageWithContinueButton(applyView, routes.SetUpAfterSettlorDiedController.onPageLoad(fakeDraftId).url)
+      behave like pageWithContinueButton(applyView, routes.SetUpByLivingSettlorController.onPageLoad(fakeDraftId).url)
     }
   }
 }

--- a/test/views/living_settlor/individual/SettlorAliveYesNoViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorAliveYesNoViewSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.living_settlor.individual
+
+import forms.YesNoFormProvider
+import play.api.data.Form
+import play.twirl.api.HtmlFormat
+import views.behaviours.YesNoViewBehaviours
+import views.html.living_settlor.individual.SettlorAliveYesNoView
+
+class SettlorAliveYesNoViewSpec extends YesNoViewBehaviours {
+
+  private val messageKeyPrefix = "settlorAliveYesNo"
+  private val index = 0
+  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix(messageKeyPrefix)
+
+  "SettlorAliveYesNo view" must {
+
+    val view = viewFor[SettlorAliveYesNoView](Some(emptyUserAnswers))
+
+    def applyView(form: Form[_]): HtmlFormat.Appendable =
+      view.apply(form, fakeDraftId, index)(fakeRequest, messages)
+
+    behave like normalPage(applyView(form), messageKeyPrefix)
+
+    behave like pageWithBackLink(applyView(form))
+
+    behave like yesNoPage(form, applyView, messageKeyPrefix, None)
+
+    behave like pageWithASubmitButton(applyView(form))
+  }
+}

--- a/test/views/living_settlor/individual/SettlorIndividualAddressInternationalViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualAddressInternationalViewSpec.scala
@@ -28,33 +28,38 @@ import views.html.living_settlor.individual.SettlorIndividualAddressInternationa
 
 class SettlorIndividualAddressInternationalViewSpec extends InternationalAddressViewBehaviours {
 
-  val messageKeyPrefix = "settlorIndividualAddressInternational"
-  val index = 0
-  val name = FullName("First", None, "Last")
-
   override val form = new InternationalAddressFormProvider()()
+  private val index = 0
+  private val name = FullName("First", None, "Last")
 
-  "SettlorIndividualAddressInternationalView" must {
+  Seq(
+    ("settlorIndividualAddressInternational", true),
+    ("settlorIndividualAddressInternationalPastTense", false)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration) =>
 
-    val view = viewFor[SettlorIndividualAddressInternationalView](Some(emptyUserAnswers))
+      s"SettlorIndividualAddressInternationalView where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    val countryOptions: Seq[InputOption] = app.injector.instanceOf[CountryOptionsNonUK].options
+        val view = viewFor[SettlorIndividualAddressInternationalView](Some(emptyUserAnswers))
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, countryOptions, index, fakeDraftId, name)(fakeRequest, messages)
+        val countryOptions: Seq[InputOption] = app.injector.instanceOf[CountryOptionsNonUK].options
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, countryOptions, index, fakeDraftId, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like dynamicTitlePage(applyView(form), messageKey, name.toString)
 
-    behave like internationalAddress(
-      applyView,
-      Some("taskList.settlors.label"),
-      Some(messageKeyPrefix),
-      routes.SettlorIndividualAddressInternationalController.onSubmit(index, fakeDraftId).url,
-      name.toString
-    )
+        behave like pageWithBackLink(applyView(form))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like internationalAddress(
+          applyView,
+          Some("taskList.settlors.label"),
+          Some(messageKey),
+          routes.SettlorIndividualAddressInternationalController.onSubmit(index, fakeDraftId).url,
+          name.toString
+        )
+
+        behave like pageWithASubmitButton(applyView(form))
+      }
   }
 }

--- a/test/views/living_settlor/individual/SettlorIndividualAddressUKViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualAddressUKViewSpec.scala
@@ -25,30 +25,35 @@ import views.html.living_settlor.individual.SettlorIndividualAddressUKView
 
 class SettlorIndividualAddressUKViewSpec extends UkAddressViewBehaviours {
 
-  val messageKeyPrefix = "settlorIndividualAddressUK"
-  val index = 0
-  val name: FullName = FullName("First", Some("middle"), "Last")
-
   override val form = new UKAddressFormProvider()()
+  private val index = 0
+  private val name: FullName = FullName("First", Some("middle"), "Last")
 
-  "SettlorIndividualAddressUKView" must {
+  Seq(
+    ("settlorIndividualAddressUK", true),
+    ("settlorIndividualAddressUKPastTense", false)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration) =>
 
-    val view = viewFor[SettlorIndividualAddressUKView](Some(emptyUserAnswers))
+      s"SettlorIndividualAddressUKView where settlorAliveAtRegistration = $settlorAliveAtRegistration)" must {
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, fakeDraftId, index, name)(fakeRequest, messages)
+        val view = viewFor[SettlorIndividualAddressUKView](Some(emptyUserAnswers))
+
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, fakeDraftId, index, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(form), messageKey, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(form))
 
-    behave like ukAddressPage(
-      applyView,
-      Some(messageKeyPrefix),
-      name.toString
-    )
+        behave like ukAddressPage(
+          applyView,
+          Some(messageKey),
+          name.toString
+        )
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(form))
+      }
   }
 }

--- a/test/views/living_settlor/individual/SettlorIndividualAddressUKYesNoViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualAddressUKYesNoViewSpec.scala
@@ -25,24 +25,31 @@ import views.html.living_settlor.individual.SettlorIndividualAddressUKYesNoView
 
 class SettlorIndividualAddressUKYesNoViewSpec extends YesNoViewBehaviours {
 
-  val messageKeyPrefix = "settlorIndividualAddressUKYesNo"
-  val index = 0
-  val name = FullName("First", Some("Middle"), "Last")
-  val form = new YesNoFormProvider().withPrefix(messageKeyPrefix)
+  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualAddressUKYesNo")
+  private val formContentInPastTense: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualAddressUKYesNoPastTense")
+  private val index = 0
+  private val name = FullName("First", Some("Middle"), "Last")
 
-  "SettlorIndividualAddressUKYesNo view" must {
+  Seq(
+    ("settlorIndividualAddressUKYesNo", true, form),
+    ("settlorIndividualAddressUKYesNoPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-    val view = viewFor[SettlorIndividualAddressUKYesNoView](Some(emptyUserAnswers))
+      s"SettlorIndividualAddressUKYesNo view where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, fakeDraftId, index, name)(fakeRequest, messages)
+        val view = viewFor[SettlorIndividualAddressUKYesNoView](Some(emptyUserAnswers))
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, fakeDraftId, index, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like yesNoPage(form, applyView, messageKeyPrefix, None, Seq(name.toString))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like yesNoPage(formToUse, applyView, messageKey, None, Seq(name.toString))
+
+        behave like pageWithASubmitButton(applyView(formToUse))
+      }
   }
 }

--- a/test/views/living_settlor/individual/SettlorIndividualAddressYesNoViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualAddressYesNoViewSpec.scala
@@ -25,25 +25,31 @@ import views.html.living_settlor.individual.SettlorIndividualAddressYesNoView
 
 class SettlorIndividualAddressYesNoViewSpec extends YesNoViewBehaviours {
 
-  val messageKeyPrefix = "settlorIndividualAddressYesNo"
-  val index = 0
-  val name = FullName("First", Some("Middle"), "Last")
+  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualAddressYesNo")
+  private val formContentInPastTense: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualAddressYesNoPastTense")
+  private val index = 0
+  private val name = FullName("First", Some("Middle"), "Last")
 
-  val form = new YesNoFormProvider().withPrefix(messageKeyPrefix)
+  Seq(
+    ("settlorIndividualAddressYesNo", true, form),
+    ("settlorIndividualAddressYesNoPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-  "SettlorIndividualAddressYesNo view" must {
+      s"SettlorIndividualAddressYesNo view where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    val view = viewFor[SettlorIndividualAddressYesNoView](Some(emptyUserAnswers))
+        val view = viewFor[SettlorIndividualAddressYesNoView](Some(emptyUserAnswers))
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, fakeDraftId, index, name)(fakeRequest, messages)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, fakeDraftId, index, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like yesNoPage(form, applyView, messageKeyPrefix, None, Seq(name.toString))
+        behave like yesNoPage(formToUse, applyView, messageKey, None, Seq(name.toString))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(formToUse))
+      }
   }
 }

--- a/test/views/living_settlor/individual/SettlorIndividualDateOfBirthViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualDateOfBirthViewSpec.scala
@@ -27,31 +27,36 @@ import java.time.LocalDate
 
 class SettlorIndividualDateOfBirthViewSpec extends QuestionViewBehaviours[LocalDate] {
 
-  val messageKeyPrefix = "settlorIndividualDateOfBirth"
   val index = 0
-  val name = FullName("First", Some("middle"), "Last")
+  val name: FullName = FullName("First", Some("middle"), "Last")
 
   val form = new DateOfBirthFormProvider(frontendAppConfig)()
 
-  "SettlorIndividualDateOfBirthView view" must {
+  Seq(
+    ("settlorIndividualDateOfBirth", true),
+    ("settlorIndividualDateOfBirthPastTense", false)
+  ) foreach {
+    case (setUpBeforeSettlorMessage, setUpBeforeSettlorDiedBool) =>
+      s"SettlorIndividualDateOfBirthView view (when setUpBeforeSettlorDied is $setUpBeforeSettlorDiedBool)" must {
 
-    val view = viewFor[SettlorIndividualDateOfBirthView](Some(emptyUserAnswers))
+        val view = viewFor[SettlorIndividualDateOfBirthView](Some(emptyUserAnswers))
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, fakeDraftId, index, name)(fakeRequest, messages)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, fakeDraftId, index, name, setUpBeforeSettlorDiedBool)(fakeRequest, messages)
 
-    val applyViewF = (form: Form[_]) => applyView(form)
+        val applyViewF = (form: Form[_]) => applyView(form)
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(form), setUpBeforeSettlorMessage, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(form))
 
-    behave like pageWithDateFields(form, applyViewF,
-      messageKeyPrefix,
-      "value",
-      name.toString
-    )
+        behave like pageWithDateFields(form, applyViewF,
+          setUpBeforeSettlorMessage,
+          "value",
+          name.toString
+        )
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(form))
+      }
   }
 }

--- a/test/views/living_settlor/individual/SettlorIndividualIDCardViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualIDCardViewSpec.scala
@@ -27,48 +27,53 @@ import views.html.living_settlor.individual.SettlorIndividualIDCardView
 
 class SettlorIndividualIDCardViewSpec extends QuestionViewBehaviours[PassportOrIdCardDetails] {
 
-  val messageKeyPrefix = "settlorIndividualIDCard"
   val index = 0
   val name = FullName("First", Some("Middle"), "Last")
 
   override val form = new PassportOrIdCardFormProvider(frontendAppConfig)("settlorIndividualPassport")
 
-  "SettlorIndividualIDCardView" must {
+  Seq(
+    ("settlorIndividualIDCard", true),
+    ("settlorIndividualIDCardPastTense", false)
+  ) foreach {
+    case (settlorIndividualIDCardMessage, setUpBeforeSettlorDiedBool) =>
+      s"SettlorIndividualIDCardView (when setUpBeforeSettlorDied is $setUpBeforeSettlorDiedBool)" must {
 
-    val view = viewFor[SettlorIndividualIDCardView](Some(emptyUserAnswers))
+        val view = viewFor[SettlorIndividualIDCardView](Some(emptyUserAnswers))
 
-    val countryOptions: Seq[InputOption] = app.injector.instanceOf[CountryOptionsNonUK].options
+        val countryOptions: Seq[InputOption] = app.injector.instanceOf[CountryOptionsNonUK].options
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, countryOptions, fakeDraftId, index, name)(fakeRequest, messages)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, countryOptions, fakeDraftId, index, name, setUpBeforeSettlorDiedBool)(fakeRequest, messages)
 
-    val applyViewF = (form: Form[_]) => applyView(form)
+        val applyViewF = (form: Form[_]) => applyView(form)
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(form), settlorIndividualIDCardMessage, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(form))
 
-    "date fields" must {
+        "date fields" must {
 
-      behave like pageWithDateFields(form, applyViewF,
-        messageKeyPrefix,
-        "expiryDate",
-        name.toString
-      )
-    }
+          behave like pageWithDateFields(form, applyViewF,
+            settlorIndividualIDCardMessage,
+            "expiryDate",
+            name.toString
+          )
+        }
 
-    "text fields" must {
+        "text fields" must {
 
-      behave like pageWithTextFields(
-        form,
-        applyView,
-        messageKeyPrefix,
-        Seq(("number", None)),
-        name.toString
-      )
-    }
+          behave like pageWithTextFields(
+            form,
+            applyView,
+            settlorIndividualIDCardMessage,
+            Seq(("number", None)),
+            name.toString
+          )
+        }
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(form))
 
+      }
   }
 }

--- a/test/views/living_settlor/individual/SettlorIndividualNameViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualNameViewSpec.scala
@@ -17,7 +17,9 @@
 package views.living_settlor.individual
 
 import forms.living_settlor.SettlorIndividualNameFormProvider
+import models.UserAnswers
 import models.pages.FullName
+import pages.living_settlor.individual.SettlorAliveYesNoPage
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
 import views.behaviours.QuestionViewBehaviours
@@ -25,29 +27,36 @@ import views.html.living_settlor.individual.SettlorIndividualNameView
 
 class SettlorIndividualNameViewSpec extends QuestionViewBehaviours[FullName] {
 
-  val messageKeyPrefix = "settlorIndividualName"
   val index = 0
 
   override val form = new SettlorIndividualNameFormProvider()()
 
-  "SettlorIndividualNameView" must {
+  Seq(
+    ("settlorIndividualName", true),
+    ("settlorIndividualNamePastTense", false)
+  ) foreach {
+    case (setUpBeforeSettlorMessage, setUpBeforeSettlorDiedBool) =>
+      s"SettlorIndividualNameView view (when setUpBeforeSettlorDied is $setUpBeforeSettlorDiedBool)" must {
 
-    val view = viewFor[SettlorIndividualNameView](Some(emptyUserAnswers))
+        val userAnswers: UserAnswers = emptyUserAnswers.set(SettlorAliveYesNoPage(index), setUpBeforeSettlorDiedBool).success.value
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, fakeDraftId, index)(fakeRequest, messages)
+        val view = viewFor[SettlorIndividualNameView](Some(userAnswers))
 
-    behave like normalPage(applyView(form), messageKeyPrefix)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, fakeDraftId, index, setUpBeforeSettlorDied = setUpBeforeSettlorDiedBool)(fakeRequest, messages)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like normalPage(applyView(form), setUpBeforeSettlorMessage)
 
-    behave like pageWithTextFields(
-      form,
-      applyView,
-      messageKeyPrefix,
-      Seq(("firstName", None), ("middleName", None), ("lastName", None))
-    )
+        behave like pageWithBackLink(applyView(form))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithTextFields(
+          form,
+          applyView,
+          setUpBeforeSettlorMessage,
+          Seq(("firstName", None), ("middleName", None), ("lastName", None))
+        )
+
+        behave like pageWithASubmitButton(applyView(form))
+      }
   }
 }

--- a/test/views/living_settlor/individual/SettlorIndividualPassportViewSpec.scala
+++ b/test/views/living_settlor/individual/SettlorIndividualPassportViewSpec.scala
@@ -27,47 +27,52 @@ import views.html.living_settlor.individual.SettlorIndividualPassportView
 
 class SettlorIndividualPassportViewSpec extends QuestionViewBehaviours[PassportOrIdCardDetails] {
 
-  val messageKeyPrefix = "settlorIndividualPassport"
   val index = 0
   val name = FullName("First", Some("Middle"), "Last")
 
   override val form = new PassportOrIdCardFormProvider(frontendAppConfig)("settlorIndividualPassport")
 
-  "SettlorIndividualPassportView" must {
+  Seq(
+    ("settlorIndividualPassport", true),
+    ("settlorIndividualPassportPastTense", false)
+  ) foreach {
+    case (settlorIndividualPassportMessage, setUpBeforeSettlorDiedBool) =>
+      s"SettlorIndividualPassportView (when setUpBeforeSettlorDied is $setUpBeforeSettlorDiedBool)" must {
 
-    val view = viewFor[SettlorIndividualPassportView](Some(emptyUserAnswers))
+        val view = viewFor[SettlorIndividualPassportView](Some(emptyUserAnswers))
 
-    val countryOptions: Seq[InputOption] = app.injector.instanceOf[CountryOptionsNonUK].options
+        val countryOptions: Seq[InputOption] = app.injector.instanceOf[CountryOptionsNonUK].options
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, countryOptions, fakeDraftId, index, name)(fakeRequest, messages)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, countryOptions, fakeDraftId, index, name, setUpBeforeSettlorDiedBool)(fakeRequest, messages)
 
-    val applyViewF = (form: Form[_]) => applyView(form)
+        val applyViewF = (form: Form[_]) => applyView(form)
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(form), settlorIndividualPassportMessage, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(form))
 
-    "date fields" must {
+        "date fields" must {
 
-      behave like pageWithDateFields(form, applyViewF,
-        messageKeyPrefix,
-        "expiryDate",
-        name.toString
-      )
-    }
+          behave like pageWithDateFields(form, applyViewF,
+            settlorIndividualPassportMessage,
+            "expiryDate",
+            name.toString
+          )
+        }
 
-    "text fields" must {
+        "text fields" must {
 
-      behave like pageWithTextFields(
-        form,
-        applyView,
-        messageKeyPrefix,
-        Seq(("number", None)),
-        name.toString
-      )
-    }
+          behave like pageWithTextFields(
+            form,
+            applyView,
+            settlorIndividualPassportMessage,
+            Seq(("number", None)),
+            name.toString
+          )
+        }
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(form))
+      }
   }
 }

--- a/test/views/living_settlor/individual/mld5/CountryOfNationalityViewSpec.scala
+++ b/test/views/living_settlor/individual/mld5/CountryOfNationalityViewSpec.scala
@@ -25,25 +25,32 @@ import views.html.living_settlor.individual.mld5.CountryOfNationalityView
 
 class CountryOfNationalityViewSpec extends SelectCountryViewBehaviours {
 
-  private val messageKeyPrefix: String = "settlorIndividualCountryOfNationality"
   private val index: Int = 0
   private val name: FullName = FullName("First", None, "Last")
 
-  override val form: Form[String] = new CountryFormProvider().withPrefix(messageKeyPrefix)
+  override val form: Form[String] = new CountryFormProvider().withPrefix("settlorIndividualCountryOfNationality")
+  val formContentInPastTense: Form[String] = new CountryFormProvider().withPrefix("settlorIndividualCountryOfNationalityPastTense")
 
-  "CountryOfNationality View" must {
+  Seq(
+    ("settlorIndividualCountryOfNationality", true, form),
+    ("settlorIndividualCountryOfNationalityPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-    val view = viewFor[CountryOfNationalityView](Some(emptyUserAnswers))
+      s"CountryOfNationality View where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, index, fakeDraftId, countryOptions, name)(fakeRequest, messages)
+        val view = viewFor[CountryOfNationalityView](Some(emptyUserAnswers))
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like selectCountryPage(form, applyView, messageKeyPrefix, name.toString)
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like selectCountryPage(formToUse, applyView, messageKey, name.toString)
+
+        behave like pageWithASubmitButton(applyView(formToUse))
+      }
   }
 }

--- a/test/views/living_settlor/individual/mld5/CountryOfResidencyViewSpec.scala
+++ b/test/views/living_settlor/individual/mld5/CountryOfResidencyViewSpec.scala
@@ -25,25 +25,31 @@ import views.html.living_settlor.individual.mld5.CountryOfResidencyView
 
 class CountryOfResidencyViewSpec extends SelectCountryViewBehaviours {
 
-  private val messageKeyPrefix: String = "settlorIndividualCountryOfResidency"
+  override val form: Form[String] = new CountryFormProvider().withPrefix("settlorIndividualCountryOfResidency")
   private val index: Int = 0
   private val name: FullName = FullName("First", None, "Last")
+  private val formContentInPastTense: Form[String] = new CountryFormProvider().withPrefix("settlorIndividualCountryOfResidencyPastTense")
 
-  override val form: Form[String] = new CountryFormProvider().withPrefix(messageKeyPrefix)
+  Seq(
+    ("settlorIndividualCountryOfResidency", true, form),
+    ("settlorIndividualCountryOfResidencyPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-  "CountryOfResidency View" must {
+      s"CountryOfResidency View where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    val view = viewFor[CountryOfResidencyView](Some(emptyUserAnswers))
+        val view = viewFor[CountryOfResidencyView](Some(emptyUserAnswers))
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, index, fakeDraftId, countryOptions, name)(fakeRequest, messages)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, index, fakeDraftId, countryOptions, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like selectCountryPage(form, applyView, messageKeyPrefix, name.toString)
+        behave like selectCountryPage(formToUse, applyView, messageKey, name.toString)
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(formToUse))
+      }
   }
 }

--- a/test/views/living_settlor/individual/mld5/CountryOfResidencyYesNoViewSpec.scala
+++ b/test/views/living_settlor/individual/mld5/CountryOfResidencyYesNoViewSpec.scala
@@ -25,27 +25,34 @@ import views.html.living_settlor.individual.mld5.CountryOfResidencyYesNoView
 
 class CountryOfResidencyYesNoViewSpec extends YesNoViewBehaviours {
 
-  private val messageKeyPrefix: String = "settlorIndividualCountryOfResidencyYesNo"
   private val index: Int = 0
   private val name: FullName = FullName("First", None, "Last")
 
-  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix(messageKeyPrefix)
+  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualCountryOfResidencyYesNo")
+  private val formContentInPastTense: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualCountryOfResidencyYesNoPastTense")
 
-  "CountryOfResidencyYesNo View" must {
+  Seq(
+    ("settlorIndividualCountryOfResidencyYesNo", true, form),
+    ("settlorIndividualCountryOfResidencyYesNoPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-    val view = viewFor[CountryOfResidencyYesNoView](Some(emptyUserAnswers))
+      s"CountryOfResidencyYesNo View where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, index, fakeDraftId, name)(fakeRequest, messages)
+        val view = viewFor[CountryOfResidencyYesNoView](Some(emptyUserAnswers))
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, index, fakeDraftId, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like yesNoPage(form, applyView, messageKeyPrefix, None, Seq(name.toString))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like yesNoPage(formToUse, applyView, messageKey, Some(messageKey), Seq(name.toString))
 
-    behave like pageWithHint(applyView(form), s"$messageKeyPrefix.hint")
+        behave like pageWithASubmitButton(applyView(formToUse))
+
+        behave like pageWithHint(applyView(formToUse), expectedHintKey = s"$messageKey.hint")
+      }
   }
 }

--- a/test/views/living_settlor/individual/mld5/UkCountryOfNationalityYesNoViewSpec.scala
+++ b/test/views/living_settlor/individual/mld5/UkCountryOfNationalityYesNoViewSpec.scala
@@ -25,25 +25,32 @@ import views.html.living_settlor.individual.mld5.UkCountryOfNationalityYesNoView
 
 class UkCountryOfNationalityYesNoViewSpec extends YesNoViewBehaviours {
 
-  private val messageKeyPrefix: String = "settlorIndividualUkCountryOfNationalityYesNo"
   private val index: Int = 0
   private val name: FullName = FullName("First", None, "Last")
 
-  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix(messageKeyPrefix)
+  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualUkCountryOfNationalityYesNo")
+  private val formContentInPastTense: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualUkCountryOfNationalityYesNoPastTense")
 
-  "UkCountryOfNationalityYesNo View" must {
+  Seq(
+    ("settlorIndividualUkCountryOfNationalityYesNo", true, form),
+    ("settlorIndividualUkCountryOfNationalityYesNoPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-    val view = viewFor[UkCountryOfNationalityYesNoView](Some(emptyUserAnswers))
+      s"UkCountryOfNationalityYesNo View where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, index, fakeDraftId, name)(fakeRequest, messages)
+        val view = viewFor[UkCountryOfNationalityYesNoView](Some(emptyUserAnswers))
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, index, fakeDraftId, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like yesNoPage(form, applyView, messageKeyPrefix, None, Seq(name.toString))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like yesNoPage(formToUse, applyView, messageKey, None, Seq(name.toString))
+
+        behave like pageWithASubmitButton(applyView(formToUse))
+      }
   }
 }

--- a/test/views/living_settlor/individual/mld5/UkCountryOfResidencyYesNoViewSpec.scala
+++ b/test/views/living_settlor/individual/mld5/UkCountryOfResidencyYesNoViewSpec.scala
@@ -25,25 +25,31 @@ import views.html.living_settlor.individual.mld5.UkCountryOfResidencyYesNoView
 
 class UkCountryOfResidencyYesNoViewSpec extends YesNoViewBehaviours {
 
-  private val messageKeyPrefix: String = "settlorIndividualUkCountryOfResidencyYesNo"
+  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualUkCountryOfResidencyYesNo")
+  private val formContentInPastTense: Form[Boolean] = new YesNoFormProvider().withPrefix("settlorIndividualUkCountryOfResidencyYesNoPastTense")
   private val index: Int = 0
   private val name: FullName = FullName("First", None, "Last")
 
-  override val form: Form[Boolean] = new YesNoFormProvider().withPrefix(messageKeyPrefix)
+  Seq(
+    ("settlorIndividualUkCountryOfResidencyYesNo", true, form),
+    ("settlorIndividualUkCountryOfResidencyYesNoPastTense", false, formContentInPastTense)
+  ) foreach {
+    case (messageKey, settlorAliveAtRegistration, formToUse) =>
 
-  "UkCountryOfResidencyYesNo View" must {
+      s"UkCountryOfResidencyYesNo View where settlorAliveAtRegistration = $settlorAliveAtRegistration" must {
 
-    val view = viewFor[UkCountryOfResidencyYesNoView](Some(emptyUserAnswers))
+        val view = viewFor[UkCountryOfResidencyYesNoView](Some(emptyUserAnswers))
 
-    def applyView(form: Form[_]): HtmlFormat.Appendable =
-      view.apply(form, index, fakeDraftId, name)(fakeRequest, messages)
+        def applyView(form: Form[_]): HtmlFormat.Appendable =
+          view.apply(form, index, fakeDraftId, name, settlorAliveAtRegistration)(fakeRequest, messages)
 
-    behave like dynamicTitlePage(applyView(form), messageKeyPrefix, name.toString)
+        behave like dynamicTitlePage(applyView(formToUse), messageKey, name.toString)
 
-    behave like pageWithBackLink(applyView(form))
+        behave like pageWithBackLink(applyView(formToUse))
 
-    behave like yesNoPage(form, applyView, messageKeyPrefix, None, Seq(name.toString))
+        behave like yesNoPage(formToUse, applyView, messageKey, None, Seq(name.toString))
 
-    behave like pageWithASubmitButton(applyView(form))
+        behave like pageWithASubmitButton(applyView(formToUse))
+      }
   }
 }

--- a/test/views/trust_type/SetUpByLivingSettlorViewSpec.scala
+++ b/test/views/trust_type/SetUpByLivingSettlorViewSpec.scala
@@ -20,19 +20,19 @@ import forms.YesNoFormProvider
 import play.api.data.Form
 import play.twirl.api.HtmlFormat
 import views.behaviours.YesNoViewBehaviours
-import views.html.trust_type.SetUpAfterSettlorDiedView
+import views.html.trust_type.SetUpByLivingSettlorView
 
-class SetUpAfterSettlorDiedViewSpec extends YesNoViewBehaviours {
+class SetUpByLivingSettlorViewSpec extends YesNoViewBehaviours {
 
-  val messageKeyPrefix = "setUpAfterSettlorDiedYesNo"
+  val messageKeyPrefix = "setUpByLivingSettlorYesNo"
 
 
-  val form = new YesNoFormProvider().withPrefix("setUpAfterSettlorDiedYesNo")
+  val form = new YesNoFormProvider().withPrefix("setUpByLivingSettlorYesNo")
 
-  "SetUpAfterSettlorDied view" when {
+  "SetUpByLivingSettlor view" when {
 
     "for a taxable trust" must {
-      val view = viewFor[SetUpAfterSettlorDiedView](Some(emptyUserAnswers))
+      val view = viewFor[SetUpByLivingSettlorView](Some(emptyUserAnswers))
 
       def applyView(form: Form[_]): HtmlFormat.Appendable =
         view.apply(form, fakeDraftId, isTaxable = true)(fakeRequest, messages)
@@ -42,13 +42,13 @@ class SetUpAfterSettlorDiedViewSpec extends YesNoViewBehaviours {
       behave like pageWithBackLink(applyView(form))
 
 
-      behave like yesNoPage(form, applyView, messageKeyPrefix, Some(messageKeyPrefix))
+      behave like yesNoPage(form, applyView, messageKeyPrefix)
 
       behave like pageWithASubmitButton(applyView(form))
     }
 
     "for a non taxable trust" must {
-      val view = viewFor[SetUpAfterSettlorDiedView](Some(emptyUserAnswers))
+      val view = viewFor[SetUpByLivingSettlorView](Some(emptyUserAnswers))
 
       def applyView(form: Form[_]): HtmlFormat.Appendable =
         view.apply(form, fakeDraftId, isTaxable = false)(fakeRequest, messages)


### PR DESCRIPTION
PR relates to updates made to the [trusts-frontend](https://github.com/hmrc/trusts-frontend/pull/860) to improve the register settlor journey.

**Changes:**
- Set up after the settlor died page has changed to set up by a living settlor - logic has changed too
- Created a new page to the living settlor journeys (settlorAliveYesNo page)
- Mental capacity question is skipped if the settlor is not alive at the time of registration
- Content should be in past tense when the user answers "no" to settlor alive at registration question
- Updated the registration JSON to include a field for the settlorYesNo page (`aliveAtRegistration`). This field is removed before the registration is submitted (part of [trusts-frontend changes](https://github.com/hmrc/trusts-frontend/pull/860))
- Updated README.md file


Run this branch against the following changes:
**trusts-frontend** ([Branch](https://github.com/hmrc/trusts-frontend/tree/DDCE-3809))
PR: https://github.com/hmrc/trusts-frontend/pull/860

**Acceptance tests** ([Branch](https://github.com/hmrc/trusts-acceptance-tests/tree/CR-PR013089))
PR: https://github.com/hmrc/trusts-acceptance-tests/pull/760

**Performance tests** ([Branch](https://github.com/hmrc/trusts-performance-tests/tree/CR-PR013089))
PR: https://github.com/hmrc/trusts-performance-tests/pull/119