### PR TITLE
DDCE-3810: updated the logic for settlor individual check answers page

### DIFF
--- a/app/controllers/living_settlor/individual/SettlorIndividualAnswerController.scala
+++ b/app/controllers/living_settlor/individual/SettlorIndividualAnswerController.scala
@@ -57,7 +57,8 @@ class SettlorIndividualAnswerController @Inject()(
   def onPageLoad(index: Int, draftId: String): Action[AnyContent] = actions(index, draftId) {
     implicit request =>
 
-      val section = livingSettlorPrintHelper.checkDetailsSection(request.userAnswers, request.name.toString, draftId, index)
+      val messageKeyPrefix =  if(request.settlorAliveAtRegistration(index)) None else Some("PastTense")
+      val section = livingSettlorPrintHelper.checkDetailsSection(request.userAnswers, request.name.toString, draftId, index, prefix = messageKeyPrefix)
 
       Ok(view(routes.SettlorIndividualAnswerController.onSubmit(index, draftId), Seq(section)))
   }
@@ -71,10 +72,9 @@ class SettlorIndividualAnswerController @Inject()(
             draftRegistrationService.removeDeceasedSettlorMappedPiece(draftId)
             Redirect(navigator.nextPage(SettlorIndividualAnswerPage, draftId)(updatedAnswers))
           }
-        case Failure(_) => {
+        case Failure(_) =>
           logger.error("[SettlorIndividualAnswerController][onSubmit] Error while storing user answers")
           Future.successful(InternalServerError(technicalErrorView()))
-        }
       }
   }
 

--- a/app/utils/print/BusinessSettlorPrintHelper.scala
+++ b/app/utils/print/BusinessSettlorPrintHelper.scala
@@ -30,7 +30,7 @@ class BusinessSettlorPrintHelper @Inject()(answerRowConverter: AnswerRowConverte
                                            trustTypePrintHelper: TrustTypePrintHelper)
   extends SettlorPrintHelper(trustTypePrintHelper, answerRowConverter) {
 
-  override def answerRows(index: Int, draftId: String)
+  override def answerRows(index: Int, draftId: String, prefix: Option[String] = None)
                          (bound: AnswerRowConverter#Bound)
                          (implicit messages: Messages): Seq[Option[AnswerRow]] = Seq(
     bound.enumQuestion(SettlorIndividualOrBusinessPage(index), "settlorIndividualOrBusiness", SettlorIndividualOrBusinessController.onPageLoad(index, draftId).url, "settlorIndividualOrBusiness"),

--- a/app/utils/print/DeceasedSettlorPrintHelper.scala
+++ b/app/utils/print/DeceasedSettlorPrintHelper.scala
@@ -28,7 +28,7 @@ class DeceasedSettlorPrintHelper @Inject()(answerRowConverter: AnswerRowConverte
                                            trustTypePrintHelper: TrustTypePrintHelper)
   extends SettlorPrintHelper(trustTypePrintHelper, answerRowConverter) {
 
-  override def answerRows(index: Int, draftId: String)
+  override def answerRows(index: Int, draftId: String, prefix: Option[String] = None)
                          (bound: AnswerRowConverter#Bound)
                          (implicit messages: Messages): Seq[Option[AnswerRow]] = Seq(
     bound.nameQuestion(SettlorsNamePage, "settlorsName", SettlorsNameController.onPageLoad(draftId).url),

--- a/app/utils/print/LivingSettlorPrintHelper.scala
+++ b/app/utils/print/LivingSettlorPrintHelper.scala
@@ -30,30 +30,36 @@ class LivingSettlorPrintHelper @Inject()(answerRowConverter: AnswerRowConverter,
                                          trustTypePrintHelper: TrustTypePrintHelper)
   extends SettlorPrintHelper(trustTypePrintHelper, answerRowConverter) {
 
-  override def answerRows(index: Int, draftId: String)
+  override def answerRows(index: Int, draftId: String, prefix: Option[String] = None)
                          (bound: AnswerRowConverter#Bound)
-                         (implicit messages: Messages): Seq[Option[AnswerRow]] = Seq(
-    bound.enumQuestion(SettlorIndividualOrBusinessPage(index), "settlorIndividualOrBusiness", SettlorIndividualOrBusinessController.onPageLoad(index, draftId).url, "settlorIndividualOrBusiness"),
-    bound.nameQuestion(SettlorIndividualNamePage(index), "settlorIndividualName", SettlorIndividualNameController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorIndividualDateOfBirthYesNoPage(index), "settlorIndividualDateOfBirthYesNo", SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, draftId).url),
-    bound.dateQuestion(SettlorIndividualDateOfBirthPage(index), "settlorIndividualDateOfBirth", SettlorIndividualDateOfBirthController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(CountryOfNationalityYesNoPage(index), "settlorIndividualCountryOfNationalityYesNo", CountryOfNationalityYesNoController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(UkCountryOfNationalityYesNoPage(index), "settlorIndividualUkCountryOfNationalityYesNo", UkCountryOfNationalityYesNoController.onPageLoad(index, draftId).url),
-    bound.countryQuestion(CountryOfNationalityPage(index), UkCountryOfNationalityYesNoPage(index), "settlorIndividualCountryOfNationality", CountryOfNationalityController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorIndividualNINOYesNoPage(index), "settlorIndividualNINOYesNo", SettlorIndividualNINOYesNoController.onPageLoad(index, draftId).url),
-    bound.ninoQuestion(SettlorIndividualNINOPage(index), "settlorIndividualNINO", SettlorIndividualNINOController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(CountryOfResidencyYesNoPage(index), "settlorIndividualCountryOfResidencyYesNo", CountryOfResidencyYesNoController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(UkCountryOfResidencyYesNoPage(index), "settlorIndividualUkCountryOfResidencyYesNo", UkCountryOfResidencyYesNoController.onPageLoad(index, draftId).url),
-    bound.countryQuestion(CountryOfResidencyPage(index), UkCountryOfResidencyYesNoPage(index), "settlorIndividualCountryOfResidency", CountryOfResidencyController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorAddressYesNoPage(index), "settlorIndividualAddressYesNo", SettlorIndividualAddressYesNoController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorAddressUKYesNoPage(index), "settlorIndividualAddressUKYesNo", SettlorIndividualAddressUKYesNoController.onPageLoad(index, draftId).url),
-    bound.addressQuestion(SettlorAddressUKPage(index), "settlorIndividualAddressUK", SettlorIndividualAddressUKController.onPageLoad(index, draftId).url),
-    bound.addressQuestion(SettlorAddressInternationalPage(index), "settlorIndividualAddressInternational", SettlorIndividualAddressInternationalController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorIndividualPassportYesNoPage(index), "settlorIndividualPassportYesNo", SettlorIndividualPassportYesNoController.onPageLoad(index, draftId).url),
-    bound.passportOrIdCardDetailsQuestion(SettlorIndividualPassportPage(index), "settlorIndividualPassport", SettlorIndividualPassportController.onPageLoad(index, draftId).url),
-    bound.yesNoQuestion(SettlorIndividualIDCardYesNoPage(index), "settlorIndividualIDCardYesNo", SettlorIndividualIDCardYesNoController.onPageLoad(index, draftId).url),
-    bound.passportOrIdCardDetailsQuestion(SettlorIndividualIDCardPage(index), "settlorIndividualIDCard", SettlorIndividualIDCardController.onPageLoad(index, draftId).url),
-    bound.enumQuestion(MentalCapacityYesNoPage(index), "settlorIndividualMentalCapacityYesNo", MentalCapacityYesNoController.onPageLoad(index, draftId).url, "site")
-  )
+                         (implicit messages: Messages): Seq[Option[AnswerRow]] = {
+
+    val messageKeyPrefix = prefix.getOrElse("")
+
+    Seq(
+      bound.enumQuestion(SettlorIndividualOrBusinessPage(index), "settlorIndividualOrBusiness", SettlorIndividualOrBusinessController.onPageLoad(index, draftId).url, "settlorIndividualOrBusiness"),
+      bound.yesNoQuestion(SettlorAliveYesNoPage(index), "settlorAliveYesNo", SettlorAliveYesNoController.onPageLoad(index, draftId).url),
+      bound.nameQuestion(SettlorIndividualNamePage(index), s"settlorIndividualName$messageKeyPrefix", SettlorIndividualNameController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorIndividualDateOfBirthYesNoPage(index), "settlorIndividualDateOfBirthYesNo", SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, draftId).url),
+      bound.dateQuestion(SettlorIndividualDateOfBirthPage(index), s"settlorIndividualDateOfBirth$messageKeyPrefix", SettlorIndividualDateOfBirthController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(CountryOfNationalityYesNoPage(index), "settlorIndividualCountryOfNationalityYesNo", CountryOfNationalityYesNoController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(UkCountryOfNationalityYesNoPage(index), s"settlorIndividualUkCountryOfNationalityYesNo$messageKeyPrefix", UkCountryOfNationalityYesNoController.onPageLoad(index, draftId).url),
+      bound.countryQuestion(CountryOfNationalityPage(index), UkCountryOfNationalityYesNoPage(index), s"settlorIndividualCountryOfNationality$messageKeyPrefix", CountryOfNationalityController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorIndividualNINOYesNoPage(index), "settlorIndividualNINOYesNo", SettlorIndividualNINOYesNoController.onPageLoad(index, draftId).url),
+      bound.ninoQuestion(SettlorIndividualNINOPage(index), "settlorIndividualNINO", SettlorIndividualNINOController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(CountryOfResidencyYesNoPage(index), s"settlorIndividualCountryOfResidencyYesNo$messageKeyPrefix", CountryOfResidencyYesNoController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(UkCountryOfResidencyYesNoPage(index), s"settlorIndividualUkCountryOfResidencyYesNo$messageKeyPrefix", UkCountryOfResidencyYesNoController.onPageLoad(index, draftId).url),
+      bound.countryQuestion(CountryOfResidencyPage(index), UkCountryOfResidencyYesNoPage(index), s"settlorIndividualCountryOfResidency$messageKeyPrefix", CountryOfResidencyController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorAddressYesNoPage(index), s"settlorIndividualAddressYesNo$messageKeyPrefix", SettlorIndividualAddressYesNoController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorAddressUKYesNoPage(index), s"settlorIndividualAddressUKYesNo$messageKeyPrefix", SettlorIndividualAddressUKYesNoController.onPageLoad(index, draftId).url),
+      bound.addressQuestion(SettlorAddressUKPage(index), s"settlorIndividualAddressUK$messageKeyPrefix", SettlorIndividualAddressUKController.onPageLoad(index, draftId).url),
+      bound.addressQuestion(SettlorAddressInternationalPage(index), s"settlorIndividualAddressInternational$messageKeyPrefix", SettlorIndividualAddressInternationalController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorIndividualPassportYesNoPage(index), "settlorIndividualPassportYesNo", SettlorIndividualPassportYesNoController.onPageLoad(index, draftId).url),
+      bound.passportOrIdCardDetailsQuestion(SettlorIndividualPassportPage(index), s"settlorIndividualPassport$messageKeyPrefix", SettlorIndividualPassportController.onPageLoad(index, draftId).url),
+      bound.yesNoQuestion(SettlorIndividualIDCardYesNoPage(index), "settlorIndividualIDCardYesNo", SettlorIndividualIDCardYesNoController.onPageLoad(index, draftId).url),
+      bound.passportOrIdCardDetailsQuestion(SettlorIndividualIDCardPage(index), s"settlorIndividualIDCard$messageKeyPrefix", SettlorIndividualIDCardController.onPageLoad(index, draftId).url),
+      bound.enumQuestion(MentalCapacityYesNoPage(index), "settlorIndividualMentalCapacityYesNo", MentalCapacityYesNoController.onPageLoad(index, draftId).url, "site")
+    )
+  }
 
 }

--- a/app/utils/print/SettlorPrintHelper.scala
+++ b/app/utils/print/SettlorPrintHelper.scala
@@ -32,32 +32,32 @@ abstract class SettlorPrintHelper(trustTypePrintHelper: TrustTypePrintHelper,
     answerSection(userAnswers, name, index, draftId)(headingKey, sectionKey(index))
   }
 
-  def checkDetailsSection(userAnswers: UserAnswers, name: String, draftId: String, index: Int = 0)
+  def checkDetailsSection(userAnswers: UserAnswers, name: String, draftId: String, index: Int = 0, prefix: Option[String] = None)
                          (implicit messages: Messages): AnswerSection = {
-    answerSection(userAnswers, name, index, draftId)(None, None)
+    answerSection(userAnswers, name, index, draftId, prefix)(None, None)
   }
 
-  private def answerSection(userAnswers: UserAnswers, name: String, index: Int, draftId: String)
+  private def answerSection(userAnswers: UserAnswers, name: String, index: Int, draftId: String, prefix: Option[String] = None)
                            (heading: Option[String], section: Option[String])
                            (implicit messages: Messages): AnswerSection = {
     AnswerSection(
       headingKey = heading,
-      rows = answerRows(userAnswers, name, index, draftId),
+      rows = answerRows(userAnswers, name, index, draftId, prefix),
       sectionKey = section,
       headingArgs = Seq(index + 1)
     )
   }
 
-  private def answerRows(userAnswers: UserAnswers, name: String, index: Int, draftId: String)
+  private def answerRows(userAnswers: UserAnswers, name: String, index: Int, draftId: String, prefix: Option[String])
                         (implicit messages: Messages): Seq[AnswerRow] = {
 
     val bound = answerRowConverter.bind(userAnswers, name)
 
     trustTypePrintHelper.answerRows(userAnswers, draftId) ++
-      answerRows(index, draftId)(bound).flatten
+      answerRows(index, draftId, prefix)(bound).flatten
   }
 
-  def answerRows(index: Int, draftId: String)
+  def answerRows(index: Int, draftId: String, prefix: Option[String] = None)
                 (bound: AnswerRowConverter#Bound)
                 (implicit messages: Messages): Seq[Option[AnswerRow]]
 

--- a/conf/messages
+++ b/conf/messages
@@ -164,6 +164,7 @@ removeSettlor.error.required = Select yes if you want to remove the settlor
 settlorAliveYesNo.title = Is the settlor alive at the time of registration?
 settlorAliveYesNo.heading = Is the settlor alive at the time of registration?
 settlorAliveYesNo.error.required = Select yes if the settlor is alive
+settlorAliveYesNo.checkYourAnswersLabel = Is the settlor alive at the time of registration?
 
 5mld.countryOfResidenceYesNo.title = Do you know the settlor’s last known country of residence?
 5mld.countryOfResidenceYesNo.heading = Do you know {0}’s last known country of residence?

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -217,9 +217,10 @@ removeSettlor.error.required = Dewiswch ‘Iawn’ os ydych am dynnu’r setlwr
 removeSettlor.heading = A ydych yn siŵr eich bod am dynnu {0}?
 removeSettlor.title = A ydych yn siŵr eich bod am dynnu’r setlwr?
 
-settlorAliveYesNo.title = Is the settlor alive at the time of registration?
-settlorAliveYesNo.heading = Is the settlor alive at the time of registration?
-settlorAliveYesNo.error.required = Select yes if the settlor is alive
+settlorAliveYesNo.title = A yw’r setlwr yn fyw ar adeg y cofrestru?
+settlorAliveYesNo.heading = A yw’r setlwr yn fyw ar adeg y cofrestru?
+settlorAliveYesNo.error.required = Dewiswch ‘Iawn’ os yw’r setlwr yn fyw
+settlorAliveYesNo.checkYourAnswersLabel = A yw’r setlwr yn fyw ar adeg y cofrestru?
 
 session_expired.guidance = Mae hyn oherwydd eich bod wedi bod yn segur ar y gwasanaeth ers 15 munud.
 session_expired.guidance.2 = Bydd angen i chi fewngofnodi er mwyn mynd yn eich blaen i gofrestru’r ymddiriedolaeth.

--- a/test/controllers/deceased_settlor/DeceasedSettlorAnswerControllerSpec.scala
+++ b/test/controllers/deceased_settlor/DeceasedSettlorAnswerControllerSpec.scala
@@ -63,7 +63,7 @@ class DeceasedSettlorAnswerControllerSpec extends SpecBase with BeforeAndAfterEa
 
       val fakeAnswerSection = AnswerSection()
 
-      when(mockPrintHelper.checkDetailsSection(any(), any(), any(), any())(any()))
+      when(mockPrintHelper.checkDetailsSection(any(), any(), any(), any(), any())(any()))
         .thenReturn(fakeAnswerSection)
 
       val answers: UserAnswers = emptyUserAnswers

--- a/test/controllers/living_settlor/business/SettlorBusinessAnswerControllerSpec.scala
+++ b/test/controllers/living_settlor/business/SettlorBusinessAnswerControllerSpec.scala
@@ -55,7 +55,7 @@ class SettlorBusinessAnswerControllerSpec extends SpecBase {
 
       val fakeAnswerSection = AnswerSection()
 
-      when(mockPrintHelper.checkDetailsSection(any(), any(), any(), any())(any()))
+      when(mockPrintHelper.checkDetailsSection(any(), any(), any(), any(), any())(any()))
         .thenReturn(fakeAnswerSection)
 
       val application: Application = applicationBuilder(userAnswers = Some(baseAnswers))

--- a/test/utils/print/LivingSettlorPrintHelperSpec.scala
+++ b/test/utils/print/LivingSettlorPrintHelperSpec.scala
@@ -64,6 +64,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val userAnswers = emptyUserAnswers
           .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -72,6 +73,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualNINOYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualNINOYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -85,6 +87,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val userAnswers = emptyUserAnswers
           .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), true).success.value
           .set(SettlorIndividualDateOfBirthPage(index), date).success.value
@@ -94,6 +97,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualDateOfBirth.checkYourAnswersLabel", answer = Html("3 February 1996"), changeUrl = Some(SettlorIndividualDateOfBirthController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -108,6 +112,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val userAnswers = emptyUserAnswers
           .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -120,6 +125,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualNINOYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualNINOYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -137,6 +143,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val userAnswers = emptyUserAnswers
           .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -149,6 +156,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualNINOYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualNINOYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -166,6 +174,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val userAnswers = emptyUserAnswers
           .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+          .set(SettlorAliveYesNoPage(index), true).success.value
           .set(SettlorIndividualNamePage(index), name).success.value
           .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
           .set(SettlorIndividualNINOYesNoPage(index), false).success.value
@@ -179,6 +188,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualNINOYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualNINOYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -195,6 +205,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
       val baseAnswers: UserAnswers = emptyUserAnswers
         .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+        .set(SettlorAliveYesNoPage(index), true).success.value
         .set(SettlorIndividualNamePage(index), name).success.value
         .set(SettlorIndividualDateOfBirthYesNoPage(index), false).success.value
 
@@ -211,6 +222,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualCountryOfNationalityYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(CountryOfNationalityYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -238,6 +250,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualCountryOfNationalityYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(CountryOfNationalityYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -269,6 +282,7 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         val expectedAnswerRows = Seq(
           AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+          AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualName.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
           AnswerRow(label = "settlorIndividualDateOfBirthYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualDateOfBirthYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
           AnswerRow(label = "settlorIndividualCountryOfNationalityYesNo.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(CountryOfNationalityYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
@@ -284,8 +298,106 @@ class LivingSettlorPrintHelperSpec extends SpecBase with ScalaCheckPropertyCheck
 
         assertThatUserAnswersProduceExpectedAnswerRows(userAnswers, expectedAnswerRows)
       }
+
+      "include prefix in the message key when defined" when {
+
+        "UK residency, UK address and Passport pages" in {
+
+          val prefix = "PastTense"
+
+          val baseAnswers = emptyUserAnswers
+            .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+            .set(SettlorAliveYesNoPage(index), false).success.value
+
+          val pagesWithPrefix = baseAnswers
+            .set(SettlorIndividualNamePage(index), name).success.value
+            .set(SettlorIndividualDateOfBirthPage(index), date).success.value
+            .set(UkCountryOfNationalityYesNoPage(index), true).success.value
+            .set(CountryOfResidencyYesNoPage(index), true).success.value
+            .set(UkCountryOfResidencyYesNoPage(index), true).success.value
+            .set(SettlorAddressYesNoPage(index), true).success.value
+            .set(SettlorAddressUKYesNoPage(index), true).success.value
+            .set(SettlorAddressUKPage(index), ukAddress).success.value
+            .set(SettlorIndividualPassportPage(index), passportOrIdCardDetails).success.value
+            .set(LivingSettlorStatus(index), Completed).success.value
+
+
+          val expectedAnswerRows = Seq(
+            AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualName$prefix.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
+            AnswerRow(label = s"settlorIndividualDateOfBirth$prefix.checkYourAnswersLabel", answer = Html("3 February 1996"), changeUrl = Some(SettlorIndividualDateOfBirthController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualUkCountryOfNationalityYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(UkCountryOfNationalityYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualCountryOfResidencyYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(CountryOfResidencyYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualUkCountryOfResidencyYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(UkCountryOfResidencyYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorIndividualAddressYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressUKYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorIndividualAddressUKYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressUK$prefix.checkYourAnswersLabel", answer = Html("Line 1<br />Line 2<br />Line 3<br />Line 4<br />AB11AB"), changeUrl = Some(SettlorIndividualAddressUKController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualPassport$prefix.checkYourAnswersLabel", answer = Html("United Kingdom<br />0987654321<br />3 February 1996"), changeUrl = Some(SettlorIndividualPassportController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString)
+          )
+
+          val checkDetailsSection = livingSettlorPrintHelper.checkDetailsSection(pagesWithPrefix, name.toString, fakeDraftId, index, Some(prefix))
+
+          checkDetailsSection mustEqual AnswerSection(
+            headingKey = None,
+            rows = expectedAnswerRows,
+            sectionKey = None,
+            headingArgs = Seq(index + 1)
+          )
+        }
+
+        "Non-UK residency, International address and ID Card pages" in {
+
+          val prefix = "PastTense"
+
+          val baseAnswers = emptyUserAnswers
+            .set(SettlorIndividualOrBusinessPage(index), Individual).success.value
+            .set(SettlorAliveYesNoPage(index), false).success.value
+
+          val pagesWithPrefix = baseAnswers
+            .set(SettlorIndividualNamePage(index), name).success.value
+            .set(SettlorIndividualDateOfBirthPage(index), date).success.value
+            .set(UkCountryOfNationalityYesNoPage(index), false).success.value
+            .set(CountryOfNationalityPage(index), "FR").success.value
+            .set(CountryOfResidencyYesNoPage(index), true).success.value
+            .set(UkCountryOfResidencyYesNoPage(index), false).success.value
+            .set(CountryOfResidencyPage(index), "FR").success.value
+            .set(SettlorAddressYesNoPage(index), true).success.value
+            .set(SettlorAddressUKYesNoPage(index), false).success.value
+            .set(SettlorAddressInternationalPage(index), nonUkAddress).success.value
+            .set(SettlorIndividualIDCardPage(index), passportOrIdCardDetails).success.value
+            .set(LivingSettlorStatus(index), Completed).success.value
+
+
+          val expectedAnswerRows = Seq(
+            AnswerRow(label = "settlorIndividualOrBusiness.checkYourAnswersLabel", answer = Html("Individual"), changeUrl = Some(SettlorIndividualOrBusinessController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = "settlorAliveYesNo.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorAliveYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualName$prefix.checkYourAnswersLabel", answer = Html("Joe Joseph Bloggs"), changeUrl = Some(SettlorIndividualNameController.onPageLoad(index, fakeDraftId).url)),
+            AnswerRow(label = s"settlorIndividualDateOfBirth$prefix.checkYourAnswersLabel", answer = Html("3 February 1996"), changeUrl = Some(SettlorIndividualDateOfBirthController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualUkCountryOfNationalityYesNo$prefix.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(UkCountryOfNationalityYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualCountryOfNationality$prefix.checkYourAnswersLabel", answer = Html("France"), changeUrl = Some(CountryOfNationalityController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualCountryOfResidencyYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(CountryOfResidencyYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualUkCountryOfResidencyYesNo$prefix.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(UkCountryOfResidencyYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualCountryOfResidency$prefix.checkYourAnswersLabel", answer = Html("France"), changeUrl = Some(CountryOfResidencyController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressYesNo$prefix.checkYourAnswersLabel", answer = Html("Yes"), changeUrl = Some(SettlorIndividualAddressYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressUKYesNo$prefix.checkYourAnswersLabel", answer = Html("No"), changeUrl = Some(SettlorIndividualAddressUKYesNoController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualAddressInternational$prefix.checkYourAnswersLabel", answer = Html("Line 1<br />Line 2<br />Line 3<br />France"), changeUrl = Some(SettlorIndividualAddressInternationalController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString),
+            AnswerRow(label = s"settlorIndividualIDCard$prefix.checkYourAnswersLabel", answer = Html("United Kingdom<br />0987654321<br />3 February 1996"), changeUrl = Some(SettlorIndividualIDCardController.onPageLoad(index, fakeDraftId).url), labelArg = name.toString)
+          )
+
+          val checkDetailsSection = livingSettlorPrintHelper.checkDetailsSection(pagesWithPrefix, name.toString, fakeDraftId, index, Some(prefix))
+
+          checkDetailsSection mustEqual AnswerSection(
+            headingKey = None,
+            rows = expectedAnswerRows,
+            sectionKey = None,
+            headingArgs = Seq(index + 1)
+          )
+        }
+      }
     }
   }
+
 
   private def assertThatUserAnswersProduceExpectedAnswerRows(userAnswers: UserAnswers,
                                                              expectedAnswerRows: Seq[AnswerRow]): Assertion = {


### PR DESCRIPTION
- When "Is the settlor alive at the time of registration?" is No the page should use the message keys with "PastTense"
- The remaining welsh translations will be added in a separate PR - https://github.com/hmrc/register-trust-settlor-frontend/pull/140